### PR TITLE
Add badges with official links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ This repository contains the relevant Docker builds to run your own node on the 
 
 [![GitHub
 contributors](https://img.shields.io/github/contributors/base-org/node)](https://github.com/base-org/node/graphs/contributors)
-
+[![GitHub commit
+activity](https://img.shields.io/github/commit-activity/w/base-org/node)](https://github.com/base-org/node/graphs/contributors)
 
 ### Supported networks
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This repository contains the relevant Docker builds to run your own node on the 
 [![GitHub commit activity](https://img.shields.io/github/commit-activity/w/base-org/node)](https://github.com/base-org/node/graphs/contributors)
 [![GitHub Stars](https://img.shields.io/github/stars/base-org/node.svg)](https://github.com/base-org/node/stargazers)
 ![GitHub repo size](https://img.shields.io/github/repo-size/base-org/node)
+[![GitHub](https://img.shields.io/github/license/base-org/node?color=blue)](https://github.com/base-org/node/blob/main/LICENSE)
 
 ### Supported networks
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ This repository contains the relevant Docker builds to run your own node on the 
 ![GitHub repo size](https://img.shields.io/github/repo-size/base-org/node)
 [![GitHub](https://img.shields.io/github/license/base-org/node?color=blue)](https://github.com/base-org/node/blob/main/LICENSE)
 
+<!-- Badge row 2 - links and profiles -->
+
+[![Website base.org](https://img.shields.io/website-up-down-green-red/https/base.org.svg)](https://base.org)
+
 ### Supported networks
 
 | Ethereum Network | Status |

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repository contains the relevant Docker builds to run your own node on the 
 [![GitHub contributors](https://img.shields.io/github/contributors/base-org/node)](https://github.com/base-org/node/graphs/contributors)
 [![GitHub commit activity](https://img.shields.io/github/commit-activity/w/base-org/node)](https://github.com/base-org/node/graphs/contributors)
 [![GitHub Stars](https://img.shields.io/github/stars/base-org/node.svg)](https://github.com/base-org/node/stargazers)
+![GitHub repo size](https://img.shields.io/github/repo-size/base-org/node)
 
 ### Supported networks
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This repository contains the relevant Docker builds to run your own node on the 
 <!-- Badge row 2 - links and profiles -->
 
 [![Website base.org](https://img.shields.io/website-up-down-green-red/https/base.org.svg)](https://base.org)
+[![Blog](https://img.shields.io/badge/blog-up-green)](https://base.mirror.xyz/)
 
 ### Supported networks
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This repository contains the relevant Docker builds to run your own node on the 
 
 [![Website base.org](https://img.shields.io/website-up-down-green-red/https/base.org.svg)](https://base.org)
 [![Blog](https://img.shields.io/badge/blog-up-green)](https://base.mirror.xyz/)
+[![Docs](https://img.shields.io/badge/docs-up-green)](https://docs.base.org/)
 
 ### Supported networks
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This repository contains the relevant Docker builds to run your own node on the 
 <!-- Badge row 3 - detailed status -->
 
 [![GitHub pull requests by-label](https://img.shields.io/github/issues-pr-raw/base-org/node)](https://github.com/base-org/node/pulls)
+[![GitHub Issues](https://img.shields.io/github/issues-raw/base-org/node.svg)](https://github.com/base-org/node/issues)
 
 ### Supported networks
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ Base is a secure, low-cost, developer-friendly Ethereum L2 built to bring the ne
 
 This repository contains the relevant Docker builds to run your own node on the Base network.
 
+<!-- Badge row 1 - status -->
+
+[![GitHub
+contributors](https://img.shields.io/github/contributors/base-org/node)](https://github.com/base-org/node/graphs/contributors)
+
+
 ### Supported networks
 
 | Ethereum Network | Status |

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ This repository contains the relevant Docker builds to run your own node on the 
 [![Docs](https://img.shields.io/badge/docs-up-green)](https://docs.base.org/)
 [![Twitter BuildOnBase](https://img.shields.io/twitter/follow/BuildOnBase?style=social)](https://twitter.com/BuildOnBase)
 
+<!-- Badge row 3 - detailed status -->
+
+[![GitHub pull requests by-label](https://img.shields.io/github/issues-pr-raw/base-org/node)](https://github.com/base-org/node/pulls)
+
 ### Supported networks
 
 | Ethereum Network | Status |

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This repository contains the relevant Docker builds to run your own node on the 
 [![Website base.org](https://img.shields.io/website-up-down-green-red/https/base.org.svg)](https://base.org)
 [![Blog](https://img.shields.io/badge/blog-up-green)](https://base.mirror.xyz/)
 [![Docs](https://img.shields.io/badge/docs-up-green)](https://docs.base.org/)
+[![Twitter BuildOnBase](https://img.shields.io/twitter/follow/BuildOnBase?style=social)](https://twitter.com/BuildOnBase)
 
 ### Supported networks
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,9 @@ This repository contains the relevant Docker builds to run your own node on the 
 
 <!-- Badge row 1 - status -->
 
-[![GitHub
-contributors](https://img.shields.io/github/contributors/base-org/node)](https://github.com/base-org/node/graphs/contributors)
-[![GitHub commit
-activity](https://img.shields.io/github/commit-activity/w/base-org/node)](https://github.com/base-org/node/graphs/contributors)
+[![GitHub contributors](https://img.shields.io/github/contributors/base-org/node)](https://github.com/base-org/node/graphs/contributors)
+[![GitHub commit activity](https://img.shields.io/github/commit-activity/w/base-org/node)](https://github.com/base-org/node/graphs/contributors)
+[![GitHub Stars](https://img.shields.io/github/stars/base-org/node.svg)](https://github.com/base-org/node/stargazers)
 
 ### Supported networks
 


### PR DESCRIPTION
Hello, in case welcome I added some nice (hopefully others think so 🤣) badges to the README. They link to various parts of the repository and also back to the Base website, blog, docs and Twitter account. You can play with them using the [README on my fork](https://github.com/wbnns/node/blob/add-badges/README.md).

I've also included screenshots below to demonstrate the change, before and after. Each badge is its own commit in case you all would like to drop some but keep others. Cheers.

**Before:**

![Screenshot from 2023-02-28 22-24-21](https://user-images.githubusercontent.com/1130872/222044797-def52c4e-8bf1-424e-be59-4fc97bfe91ba.png)

**After:**

![Screenshot from 2023-02-28 22-37-02](https://user-images.githubusercontent.com/1130872/222045997-9c59ea92-27a4-4154-a66b-6ccf2b2f658b.png)
