### PR TITLE
SECURITY: Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,3 @@
+# Security Policy
+
+Report your findings to our H1 program: https://hackerone.com/coinbase

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,38 @@
-# Security Policy
+# Security
 
-Report your findings to our H1 program: https://hackerone.com/coinbase
+## Bug bounty program
+
+In line with our strategy of being the safest way for users to access crypto:
+
++ Coinbase will be extending our [best-in-industry][1] million-dollar [HackerOne bug bounty program][2]
+to cover the Base network, the Base bridge contracts, and Base infrastructure.
+
++ Coinbase will be working in tandem with OP Labs to harden the security
+guarantees of Bedrock and accelerate the timeline for decentralized
+fault-proofs on the [OP Stack][3].
+
++ Coinbase's bug bounty program will run alongside Optimism's existing [Immunefi Bedrock bounty program][4]
+to support the open source [Bedrock][5] OP Stack framework.
+
+## Reporting vulnerabilities
+
+All potential vulnerability reports can be submitted via the [HackerOne][6]
+platform.
+
+The HackerOne platform allows us to have a centralized and single reporting
+source for us to deliver optimized SLA's and results. All reports submitted to
+the platform are triaged around the clock by our team of Coinbase engineers
+with domain knowledge, assuring the best quality of review.
+
+For more information on reporting vulnerabilities and our HackerOne bug bounty
+program, view our [security program policies][7].
+
+[1]: https://www.coinbase.com/blog/celebrating-10-years-of-our-bug-bounty-program
+[2]: https://hackerone.com/coinbase?type=team 
+[3]: https://stack.optimism.io/
+[4]: https://immunefi.com/bounty/optimism/
+[5]: https://stack.optimism.io/docs/releases/bedrock/
+[6]: https://hackerone.com/coinbase
+[7]: https://hackerone.com/coinbase?view_policy=true
+
+


### PR DESCRIPTION
Similarly to PR #11 , I grabbed this from https://github.com/coinbase/salus/blob/master/SECURITY.md thinking it would be OK to use. This template simply instructs people with reports to submit them via [Coinbase's HackerOne page](https://hackerone.com/coinbase).