### PR TITLE
Add Issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,51 @@
+name: Bug report
+description: Create a report to help us improve
+title: "Bug: "
+labels: ["type: bug"]
+
+body:
+  - type: input
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: A clear and concise description of what you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional info
+      description: If applicable, include links to screenshots or error logs
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Please fill in details for bugs reported in your environment
+      placeholder: |
+        - OS: [e.g. Fedora]
+        - Version [e.g. 37]
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Base Documentation
+    url: https://docs.base.org/
+    about: Base is a secure, low-cost, developer-friendly Ethereum L2 built to bring the next billion users to web3.
+

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,37 @@
+name: Feature request
+description: Suggest an idea for this project
+title: "Feature Request: "
+labels: ["type: enhancement"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This issue form is for feature requests only!
+        If you've found a bug, please use [bug_report](/new?template=bug_report.yml)
+  - type: textarea
+    id: problem
+    attributes:
+      label: Is your feature request related to a problem? Please describe.
+      description: A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives you've considered
+      description: Describe any alternative solutions or features you've considered.
+
+  - type: textarea
+    id: other
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request here.
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+### _Summary_
+
+<!--
+  What changed? Link to relevant issues.
+-->
+
+### _How did you test your changes?_
+
+<!--
+  Verify changes. Include relevant screenshots/videos
+-->
+


### PR DESCRIPTION
This PR adds Issue and PR templates to the repository to help organize the way issues and pull requests are opened, by standardizing the type of information that gets submitted.

I pulled these over from the [Coinbase Wallet SDK](https://github.com/coinbase/coinbase-wallet-sdk/tree/master/.github); they're the same ones that are being used there, except refactored for Base. You can [play with opening an issue over there](https://github.com/coinbase/coinbase-wallet-sdk/issues/new/choose) to get an idea of what it looks like. *Note:* I dropped the smartphone-related info from them before adding to this repo since it's not going to be relevant for the purposes of running a node.

When/if #15 is incorporated I would also follow-on to update this in the future to ask users to include a version when opening an issue. I left this section out for now since there is no versioning at present in the repo. 