### PR TITLE
Add safeguard for missing jq in the system

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Note: Some L1 nodes (e.g. Erigon) do not support fetching storage proofs. You ca
 
 Sync speed depends on your L1 node, as the majority of the chain is derived from data submitted to the L1. You can check your syncing status using the `optimism_syncStatus` RPC on the `op-node` container. Example:
 ```
+command -v jq  &> /dev/null || { echo "jq is not installed" 1>&2 ; }
 echo Latest synced block behind by: \
 $((($( date +%s )-\
 $( curl -s -d '{"id":0,"jsonrpc":"2.0","method":"optimism_syncStatus"}' -H "Content-Type: application/json" http://localhost:7545 |


### PR DESCRIPTION
Warn developer for missing package, as original error message does not say this straight.

Another more "polluted" options is 
```
command -v jq &> /dev/null && echo Latest synced block behind by: \
$((($( date +%s )-\
$( curl -s -d '{"id":0,"jsonrpc":"2.0","method":"optimism_syncStatus"}' -H "Content-Type: application/json" http://localhost:7545 |
   jq -r .result.unsafe_l2.timestamp))/60)) minutes || { echo "mvn is not installed" 1>&2 ; }
```