### PR TITLE
Bump op-node and op-geth commits to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.19 as op
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV COMMIT=759c0b297c3dfa05370c27b9380c7bffb67b12d2
+ENV COMMIT=8a308fc18d36b4ffa89fa4d0ab50c324382c0477
 RUN git init && \
     git remote add origin $REPO && \
     git fetch --depth=1 origin $COMMIT && \
@@ -18,7 +18,7 @@ FROM golang:1.19 as geth
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/op-geth.git
-ENV COMMIT=c407b2a217b78d13d33f86873bbf38af6e73523e
+ENV COMMIT=11f0554a4313ea0e0aaddef194058b057aadce5c
 RUN git init && \
     git remote add origin $REPO && \
     git fetch --depth=1 origin $COMMIT && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,6 @@ services:
       - ./op-node-entrypoint.sh
     environment:
       - OP_NODE_L1_ETH_RPC=https://ethereum-goerli-rpc.allthatnode.com # [recommended] replace with your preferred L1 (ethereum, not Base) node RPC URL
-      - OP_NODE_L1_TRUST_RPC=true # temporary for Goerli Shapella upgrade
       - OP_NODE_L2_ENGINE_AUTH=/tmp/engine-auth-jwt
       - OP_NODE_L2_ENGINE_AUTH_RAW=688f5d737bad920bdfb2fc2f488d6b6209eebda1dae949a8de91398d932c517a # for localdev only
       - OP_NODE_L2_ENGINE_RPC=http://geth:8551


### PR DESCRIPTION
Reliability improvements, including fix for handling shapella L1 blocks (https://github.com/ethereum-optimism/optimism/pull/5144).