### PR TITLE
Upgrade op-node and op-geth dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.19 as op
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV COMMIT=8a308fc18d36b4ffa89fa4d0ab50c324382c0477
+ENV COMMIT=09d23ee8995b7c318a4469a49276f9453535c6a9
 RUN git init && \
     git remote add origin $REPO && \
     git fetch --depth=1 origin $COMMIT && \
@@ -18,7 +18,7 @@ FROM golang:1.19 as geth
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/op-geth.git
-ENV COMMIT=11f0554a4313ea0e0aaddef194058b057aadce5c
+ENV COMMIT=24ae687be390aecb369be6b642e270188e850d81
 RUN git init && \
     git remote add origin $REPO && \
     git fetch --depth=1 origin $COMMIT && \


### PR DESCRIPTION
This includes some reliability improvements in op-node, as well as scheduling the op-geth Regolith hardfork at block 1682614800 (https://github.com/ethereum-optimism/op-geth/pull/83).