### PR TITLE
Minor .env cleanup

### DIFF
--- a/.env.goerli
+++ b/.env.goerli
@@ -1,10 +1,16 @@
 OP_GETH_GENESIS_FILE_PATH=goerli/genesis-l2.json
 OP_GETH_SEQUENCER_HTTP=https://goerli-sequencer.base.org
-# OP_GETH_ETH_STATS=nodename:secret@host:port # optional
 
-OP_NODE_L1_ETH_RPC=https://ethereum-goerli-rpc.allthatnode.com # [recommended] replace with your preferred L1 (Ethereum, not Base) node RPC URL
+# [optional] used to enable geth stats:
+# OP_GETH_ETH_STATS=nodename:secret@host:port
+
+# [recommended] replace with your preferred L1 (Ethereum, not Base) node RPC URL:
+OP_NODE_L1_ETH_RPC=https://ethereum-goerli-rpc.allthatnode.com
+
+# auth secret used by op-geth engine API:
+OP_NODE_L2_ENGINE_AUTH_RAW=688f5d737bad920bdfb2fc2f488d6b6209eebda1dae949a8de91398d932c517a
+
 OP_NODE_L2_ENGINE_AUTH=/tmp/engine-auth-jwt
-OP_NODE_L2_ENGINE_AUTH_RAW=688f5d737bad920bdfb2fc2f488d6b6209eebda1dae949a8de91398d932c517a # for localdev only
 OP_NODE_L2_ENGINE_RPC=http://geth:8551
 OP_NODE_LOG_LEVEL=info
 OP_NODE_METRICS_ADDR=0.0.0.0
@@ -20,7 +26,8 @@ OP_NODE_RPC_ADDR=0.0.0.0
 OP_NODE_RPC_PORT=8545
 OP_NODE_SNAPSHOT_LOG=/tmp/op-node-snapshot-log
 OP_NODE_VERIFIER_L1_CONFS=4
+
 # OP_NODE_L1_TRUST_RPC allows for faster syncing, but should be used *only* if your L1 RPC node
-# is fully trusted.  It also allows op-node to work with clients such as Erigon that do not
-# support storage proofs.
+# is fully trusted. It also allows op-node to work with clients such as Erigon that do not
+# support storage proofs:
 # OP_NODE_L1_TRUST_RPC=true


### PR DESCRIPTION
 - `docker`'s `--env-file` parsing doesn't like the trailing comments, so move them onto separate lines
 - minor formatting cleanup