### PR TITLE
Prefix app commands with exec for graceful shutdown

### DIFF
--- a/geth-entrypoint
+++ b/geth-entrypoint
@@ -35,7 +35,7 @@ if [ "${OP_GETH_ALLOW_UNPROTECTED_TXS+x}" = x ]; then
 	ADDITIONAL_ARGS="$ADDITIONAL_ARGS --rpc.allow-unprotected-txs=$OP_GETH_ALLOW_UNPROTECTED_TXS"
 fi
 
-./geth \
+exec ./geth \
 	--datadir="$GETH_DATA_DIR" \
 	--verbosity="$VERBOSITY" \
 	--http \

--- a/op-node-entrypoint
+++ b/op-node-entrypoint
@@ -13,4 +13,4 @@ export OP_NODE_P2P_ADVERTISE_IP=$PUBLIC_IP
 
 echo "$OP_NODE_L2_ENGINE_AUTH_RAW" > "$OP_NODE_L2_ENGINE_AUTH"
 
-./op-node
+exec ./op-node


### PR DESCRIPTION
Currently, any attempt at shutting down the container will result in a forced stop due to the app being created as its own process in the entrypoint script. Adding exec will run the app as PID 1 and handle graceful shutdowns.

Any forced shutdowns with geth or similar software usually results in corrupted and lost state that will result in syncing from a much greater timeframe on reboot.