### PR TITLE
fix: add version to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+version: '3.8'
+
 services:
   geth: # this is Optimism's geth client
     build: .


### PR DESCRIPTION
I'm not sure which version of docker-compose should be used here, I just picked the latest. The reason to add a version is explained in Docker's docs:

> Version 1 is deprecated... Compose files that do not declare a version are considered “version 1”.
https://docs.docker.com/compose/compose-file/compose-versioning/#version-1-deprecated

Fyi: Docker compose v3.8 is "It is only available with Docker Engine version 19.03.0 and higher."