### PR TITLE
Disable txpool API by default

### DIFF
--- a/geth-entrypoint
+++ b/geth-entrypoint
@@ -43,7 +43,7 @@ exec ./geth \
 	--http.vhosts="*" \
 	--http.addr=0.0.0.0 \
 	--http.port="$RPC_PORT" \
-	--http.api=web3,debug,eth,txpool,net,engine \
+	--http.api=web3,debug,eth,net,engine \
 	--authrpc.addr=0.0.0.0 \
 	--authrpc.port="$AUTHRPC_PORT" \
 	--authrpc.vhosts="*" \
@@ -52,7 +52,7 @@ exec ./geth \
 	--ws.addr=0.0.0.0 \
 	--ws.port="$WS_PORT" \
 	--ws.origins="*" \
-	--ws.api=debug,eth,txpool,net,engine \
+	--ws.api=debug,eth,net,engine \
 	--metrics \
 	--metrics.addr=0.0.0.0 \
 	--metrics.port="$METRICS_PORT" \


### PR DESCRIPTION
Base has a private mempool with gossip disabled. Disabling this for nodes by default makes sense, in case people run shared nodes. Folks can opt-in individually if they need it for a specific reason.