### PR TITLE
Bump op-geth to new release-candidate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ FROM golang:1.19 as geth
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/op-geth
-ENV VERSION=v1.101106.0
-ENV CHECKSUM=0273ea3226147ba5b04c1a6eff2d9da48e6bbff3a348b33fe13e7e34d88ba411
+ENV VERSION=v1.101200.1-rc.2
+ENV CHECKSUM=acdd027c85cf2edaec198f888a543445821182eaef461bc9d1a32527bd186ee3
 ADD --checksum=sha256:$CHECKSUM $REPO/archive/$VERSION.tar.gz ./
 
 RUN tar -xvf ./$VERSION.tar.gz --strip-components=1 && \

--- a/geth-entrypoint
+++ b/geth-entrypoint
@@ -64,5 +64,5 @@ exec ./geth \
 	--nat=extip:$HOST_IP \
 	--networkid="$CHAIN_ID" \
 	--rollup.sequencerhttp="$OP_GETH_SEQUENCER_HTTP" \
-        --port="$P2P_PORT" \
+	--port="$P2P_PORT" \
 	$ADDITIONAL_ARGS # intentionally unquoted


### PR DESCRIPTION
Upgrading from `v1.101106.0` to `v1.101200.1-rc.2`.

This brings in all of the changes included in [v1.101200.0](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101200.0), as well as a fix for some txpool leaks (see https://github.com/ethereum-optimism/op-geth/pull/122).

https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101200.1-rc.2