### PR TITLE
Update hdd requirements and add snapshot info

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This repository contains the relevant Docker builds to run your own node on the 
 We recommend you have this configuration to run a node:
 
 - at least 16 GB RAM
-- an SSD drive with at least 500 GB free
+- an SSD drive with at least 1 TB free
 
 ### Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This repository contains the relevant Docker builds to run your own node on the 
 We recommend you have this configuration to run a node:
 
 - at least 16 GB RAM
-- an SSD drive with at least 100 GB free
+- an SSD drive with at least 500 GB free
 
 ### Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,22 @@ services:
       - $HOME/data/base:/data
 ```
 
+### Snapshots
+
+If you're a prospective or current Base Node operator and would like to restore from a snapshot to save time on the initial sync, it's possible to always get the latest available snapshot of the Base chain on mainnet and/or testnet by using the following CLI commands. The snapshots are updated every hour.
+
+**Mainnet**
+
+```
+wget https://base-mainnet-archive-snapshots.s3.us-east-1.amazonaws.com/$(curl https://base-mainnet-archive-snapshots.s3.us-east-1.amazonaws.com/latest)
+```
+
+**Testnet**
+
+```
+wget https://base-goerli-archive-snapshots.s3.us-east-1.amazonaws.com/$(curl https://base-goerli-archive-snapshots.s3.us-east-1.amazonaws.com/latest)
+```
+
 ### Syncing
 
 Sync speed depends on your L1 node, as the majority of the chain is derived from data submitted to the L1. You can check your syncing status using the `optimism_syncStatus` RPC on the `op-node` container. Example:


### PR DESCRIPTION
This PR updates the hdd requirements and also adds snapshot info.

Currently to restore a snapshot for mainnet, it would require approximately 450GB of disk space. This would exceed the current minimum requirement of 100GB mentioned in the README, so I've updated it to ~500GB~ 1TB.

Closes #110 
Closes #109 