### PR TITLE
feat(ci): Pr docker build ci

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Build the Docker image
         uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,16 @@
+name: Build Image
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build the Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: false

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,4 @@
-name: Build Image
+name: Pull Request
 
 on:
   pull_request:


### PR DESCRIPTION
# What

This adds a github action workflow, similar to the on_merge `docker.yml` file that runs on `pull_request` that will build the `Dockerfile` at the root of the gitrepo in order to verify building the dockerfile still works, so that there are not merges that break the docker build.  The build will not push, as there is no login attempt step or creds specified

# Testing

You should see the job complete in the github actions