### PR TITLE
Add single-container support with supervisord

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,15 +33,19 @@ RUN go run build/ci.go install -static ./cmd/geth
 FROM golang:1.19
 
 RUN apt-get update && \
-    apt-get install -y jq curl && \
+    apt-get install -y jq curl supervisor && \
     rm -rf /var/lib/apt/lists
+RUN mkdir -p /var/log/supervisor
 
 WORKDIR /app
 
 COPY --from=op /app/op-node/bin/op-node ./
 COPY --from=geth /app/build/bin/geth ./
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY geth-entrypoint .
 COPY op-node-entrypoint .
 COPY goerli ./goerli
 COPY sepolia ./sepolia
 COPY mainnet ./mainnet
+
+CMD ["/usr/bin/supervisord"]

--- a/README.md
+++ b/README.md
@@ -78,6 +78,17 @@ services:
       - $HOME/data/base:/data
 ```
 
+#### Running in single container with `supervisord`
+
+If you'd like to run the node in a single container instead of `docker-compose`, you can use the `supervisord` entrypoint.
+This is useful for running the node in a Kubernetes cluster, for example.
+
+Note that you'll need to override some of the default configuration that assumes a multi-container environment (`OP_NODE_L2_ENGINE_RPC`) and any port conflicts (`OP_NODE_RPC_PORT`).
+Example:
+```
+docker run --env-file .env.goerli -e OP_NODE_L2_ENGINE_RPC=ws://localhost:8551 -e OP_NODE_RPC_PORT=7545 ghcr.io/base-org/node:latest
+```
+
 ### Snapshots
 
 If you're a prospective or current Base Node operator and would like to restore from a snapshot to save time on the initial sync, it's possible to always get the latest available snapshot of the Base chain on mainnet and/or testnet by using the following CLI commands. The snapshots are updated every hour.

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,16 @@
+[supervisord]
+nodaemon=true
+logfile=/dev/null
+logfile_maxbytes=0
+
+[program:op-node]
+command=/app/op-node-entrypoint
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
+
+[program:op-geth]
+command=/app/geth-entrypoint
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true


### PR DESCRIPTION
Some folks like to run a node as a single container. This PR orchestrates both binaries (op-geth and op-node) using supervisord.

`docker-compose` is still supported.