### PR TITLE
Correct port in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Sync speed depends on your L1 node, as the majority of the chain is derived from
 command -v jq  &> /dev/null || { echo "jq is not installed" 1>&2 ; }
 echo Latest synced block behind by: \
 $((($( date +%s )-\
-$( curl -s -d '{"id":0,"jsonrpc":"2.0","method":"optimism_syncStatus"}' -H "Content-Type: application/json" http://localhost:7545 |
+$( curl -s -d '{"id":0,"jsonrpc":"2.0","method":"optimism_syncStatus"}' -H "Content-Type: application/json" http://localhost:8545 |
    jq -r .result.unsafe_l2.timestamp))/60)) minutes
 ```
 


### PR DESCRIPTION
The command to check the synch status does not work as-is. Since the port is off, the response from `curl` can't be processed with `jq`:

```
-bash: (1698430784-)/60: syntax error: operand expected (error token is ")/60")
```

Port `7545` is exposed as `8545` in the default `docker-compose.yml#23`: https://github.com/base-org/node/blob/f098bb929fedff875b37733273753cafcbe98d82/docker-compose.yml#L18-L27

Assuming we want to keep the current port mapping, I suggest to change the port in the [Syncing](https://github.com/base-org/node#syncing) check command.