### PR TITLE
Support for reducing disk space requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This repository contains the relevant Docker builds to run your own node on the 
 We recommend you have this configuration to run a node:
 
 - at least 16 GB RAM
-- an SSD drive with at least 1 TB free
+- an SSD drive with at least 2 TB free
 
 ### Troubleshooting
 

--- a/geth-entrypoint
+++ b/geth-entrypoint
@@ -61,6 +61,6 @@ exec ./geth \
 	--nat=extip:$HOST_IP \
 	--rollup.sequencerhttp="$OP_GETH_SEQUENCER_HTTP" \
 	--rollup.halt=major \
-	--op-network=$OP_NODE_NETWORK" \
+	--op-network="$OP_NODE_NETWORK" \
 	--port="$P2P_PORT" \
 	$ADDITIONAL_ARGS # intentionally unquoted

--- a/geth-entrypoint
+++ b/geth-entrypoint
@@ -10,6 +10,7 @@ METRICS_PORT="${METRICS_PORT:-6060}"
 HOST_IP="0.0.0.0"
 P2P_PORT="${P2P_PORT:-30303}"
 ADDITIONAL_ARGS=""
+OP_GETH_GCMODE="${OP_GETH_GCMODE:-archive}"
 
 if [[ -z "$OP_NODE_NETWORK" ]]; then
     echo "expected OP_NODE_NETWORK to be set" 1>&2
@@ -26,6 +27,10 @@ fi
 
 if [ "${OP_GETH_ALLOW_UNPROTECTED_TXS+x}" = x ]; then
 	ADDITIONAL_ARGS="$ADDITIONAL_ARGS --rpc.allow-unprotected-txs=$OP_GETH_ALLOW_UNPROTECTED_TXS"
+fi
+
+if [ "${OP_GETH_STATE_SCHEME+x}" = x ]; then
+  ADDITIONAL_ARGS="$ADDITIONAL_ARGS --state.scheme=$OP_GETH_STATE_SCHEME"
 fi
 
 exec ./geth \
@@ -50,7 +55,7 @@ exec ./geth \
 	--metrics.addr=0.0.0.0 \
 	--metrics.port="$METRICS_PORT" \
 	--syncmode=full \
-	--gcmode=archive \
+	--gcmode="$OP_GETH_GCMODE" \
 	--nodiscover \
 	--maxpeers=100 \
 	--nat=extip:$HOST_IP \


### PR DESCRIPTION
Add `$OP_GETH_GCMODE` and `$OP_GETH_STATE_SCHEME` envvars for overriding the `--gcmode` and `--state.scheme` op-geth arguments:
 - Setting `OP_GETH_GCMODE=full` allows people to run a full node instead of an archive node
 - Setting `OP_GETH_STATE_SCHEME=path` switches the ethereum state storage scheme to `path` (defaults to `hash`)

Also updates the README clarifying disk space requirements.