### PR TITLE
Update README.md: Use aria2c for snapshot downloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,16 +95,28 @@ docker run --env-file .env.goerli -e OP_NODE_L2_ENGINE_RPC=ws://localhost:8551 -
 
 If you're a prospective or current Base Node operator and would like to restore from a snapshot to save time on the initial sync, it's always possible to download and decompress the latest available snapshot of the Base chain on mainnet and/or testnet by using the following CLI commands. The snapshots are updated every hour.
 
+#### Install aria2
+
+Debian/Ubuntu:
+```
+apt install aria2
+```
+CentOS:
+```
+yum install epel-release -y
+yum install aria2 -y
+```
+
 **Mainnet**
 
 ```
-wget https://base-mainnet-archive-snapshots.s3.us-east-1.amazonaws.com/$(curl https://base-mainnet-archive-snapshots.s3.us-east-1.amazonaws.com/latest)
+aria2c -s16 -x16 https://base-mainnet-archive-snapshots.s3.us-east-1.amazonaws.com/$(curl https://base-mainnet-archive-snapshots.s3.us-east-1.amazonaws.com/latest)
 ```
 
 **Testnet**
 
 ```
-wget https://base-goerli-archive-snapshots.s3.us-east-1.amazonaws.com/$(curl https://base-goerli-archive-snapshots.s3.us-east-1.amazonaws.com/latest)
+aria2c -s16 -x16  https://base-goerli-archive-snapshots.s3.us-east-1.amazonaws.com/$(curl https://base-goerli-archive-snapshots.s3.us-east-1.amazonaws.com/latest)
 ```
 
 Use `tar -xvf` to decompress the downloaded archive to the local data directory you previously configured a volume mapping for.


### PR DESCRIPTION
[Aria2c](https://aria2.github.io/) allow to cut downloading time by ~ 3 times.

Wget results in `eta 14h 57m`:
```
~ # wget https://base-mainnet-archive-snapshots.s3.us-east-1.amazonaws.com/$(curl https://base-mainnet-archive-snapshots.s3.us-east-1.amazonaws.com/latest)
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    38  100    38    0     0     82      0 --:--:-- --:--:-- --:--:--    82
--2023-11-17 11:22:33--  https://base-mainnet-archive-snapshots.s3.us-east-1.amazonaws.com/base-mainnet-archive-1698602049.tar.gz
Resolving base-mainnet-archive-snapshots.s3.us-east-1.amazonaws.com (base-mainnet-archive-snapshots.s3.us-east-1.amazonaws.com)... 52.216.53.42, 54.231.201.226, 52.216.204.70, ...
Connecting to base-mainnet-archive-snapshots.s3.us-east-1.amazonaws.com (base-mainnet-archive-snapshots.s3.us-east-1.amazonaws.com)|52.216.53.42|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 1341270453324 (1.2T) [binary/octet-stream]
Saving to: 'base-mainnet-archive-1698602049.tar.gz'

base-mainnet-archive-1698602049.tar.gz                  0%[                                                                                                                      ]   1012M  30.3MB/s    eta 14h 57m
```

Aria2c results in `ETA:3h15m7s`:
```
~ # aria2c -s16 -x16 https://base-mainnet-archive-snapshots.s3.us-east-1.amazonaws.com/$(curl https://base-mainnet-archive-snapshots.s3.us-east-1.amazonaws.com/latest)
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    38  100    38    0     0     90      0 --:--:-- --:--:-- --:--:--    90

11/17 11:24:24 [NOTICE] Downloading 1 item(s)
[#694275 2.0GiB/1,249GiB(0%) CN:16 DL:109MiB ETA:3h15m7s]
```

Aria2c is able to utilize 1Gbit/s channel fully. 