### PR TITLE
update Dockerfile for latest op-geth (v1.101305.3) & op-node (v1.5.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.20 as op
+FROM golang:1.21 as op
 
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.4.1
+ENV VERSION=v1.5.0
 # for verification:
-ENV COMMIT=54a7dbf8aa9b982f9c6a54cbbe448be41c0b7bc7
+ENV COMMIT=6de6b5fc81d8ee03bb776219ba25189a04712f99
 
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
@@ -14,14 +14,14 @@ RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
 RUN cd op-node && \
     make op-node
 
-FROM golang:1.20 as geth
+FROM golang:1.21 as geth
 
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/op-geth.git
-ENV VERSION=v1.101304.2
+ENV VERSION=v1.101305.3
 # for verification:
-ENV COMMIT=c6b416da212fe6713ff40b8092303d0035405a47
+ENV COMMIT=ea3c3044010f97fb3d9affa0dd3c0c2beea85882
 
 # avoid depth=1, so the geth build can read tags
 RUN git clone $REPO --branch $VERSION --single-branch . && \


### PR DESCRIPTION
also update golang to 1.21 to be consistent with optimism's release dockerfile.

This is needed for creating the ecotone testnet and delta mainnet releases.