### PR TITLE
Update runtime container to Golang 1.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN git clone $REPO --branch $VERSION --single-branch . && \
 
 RUN go run build/ci.go install -static ./cmd/geth
 
-FROM golang:1.20
+FROM golang:1.21
 
 RUN apt-get update && \
     apt-get install -y jq curl supervisor && \


### PR DESCRIPTION
The build containers were updated with #186, this updates the last layer as well.