### PR TITLE
Update op-node-entrypoint

### DIFF
--- a/op-node-entrypoint
+++ b/op-node-entrypoint
@@ -7,7 +7,7 @@ if [[ -z "$OP_NODE_NETWORK" ]]; then
 fi
 
 # wait until local geth comes up (authed so will return 401 without token)
-until [ "$(curl -s -w '%{http_code}' -o /dev/null "${OP_NODE_L2_ENGINE_RPC/ws/http}")" -eq 401 ]; do
+until [ "$(curl -s -w '%{http_code}' -o /dev/null "${OP_NODE_L2_ENGINE_RPC}/ws/http")" -eq 401 ]; do
   echo "waiting for geth to be ready"
   sleep 5
 done


### PR DESCRIPTION
This error was preventing building and starting both containers

```
[+] Running 2/0
 ✔ Container repo-geth-1  Running                                                                                                                        0.0s 
 ✔ Container repo-node-1  Running                                                                                                                        0.0s 
Attaching to geth-1, node-1
node-1  | ./op-node-entrypoint: 10: Bad substitution
node-1  | ./op-node-entrypoint: 10: [: Illegal number: 

```

after fixing it, still seeing something coming up but at least the nodes do start

```
 ✔ Container repo-geth-1  Recreated                                                                                                                      0.4s 
 ✔ Container repo-node-1  Recreated                                                                                                                     10.3s 
Attaching to geth-1, node-1
geth-1  | ./geth-entrypoint: 15: [[: not found
geth-1  | INFO [02-22|04:19:14.639] Starting geth on an OP network...        network=base-mainnet
geth-1  | INFO [02-22|04:19:14.640] Bumping default cache on mainnet         provided=1024 updated=4096
geth-1  | INFO [02-22|04:19:14.640] Enabling metrics collection 
geth-1  | INFO [02-22|04:19:14.640] Enabling stand-alone metrics HTTP endpoint address=0.0.0.0:6060
geth-1  | INFO [02-22|04:19:14.640] Starting metrics server                  addr=http://0.0.0.0:6060/debug/metrics
geth-1  | INFO [02-22|04:19:14.641] Maximum peer count                       ETH=100 LES=0 total=100
geth-1  | INFO [02-22|04:19:14.641] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"
geth-1  | INFO [02-22|04:19:14.643] Enabling recording of key preimages since archive mode is used 
geth-1  | WARN [02-22|04:19:14.644] Disabled transaction unindexing for archive node 
geth-1  | INFO [02-22|04:19:14.644] Set global gas cap                       cap=50,000,000
geth-1  | INFO [02-22|04:19:14.773] Initializing the KZG library             backend=gokzg
geth-1  | INFO [02-22|04:19:14.785] Allocated trie memory caches             clean=1.20GiB dirty=0.00B
node-1  | ./op-node-entrypoint: 4: [[: not found
node-1  | waiting for geth to be ready
geth-1  | INFO [02-22|04:19:15.410] Using leveldb as the backing database 
geth-1  | INFO [02-22|04:19:15.410] Allocated cache and file handles         database=/data/geth/chaindata cache=2.00GiB handles=1,000,000,000
node-1  | waiting for geth to be ready
geth-1  | INFO [02-22|04:19:19.906] Using LevelDB as the backing database 
geth-1  | INFO [02-22|04:19:19.907] Opened ancient database                  database=/data/geth/chaindata/ancient/chain readonly=false
geth-1  | INFO [02-22|04:19:19.934] State scheme set to already existing     scheme=hash
geth-1  | INFO [02-22|04:19:22.616]  
geth-1  | INFO [02-22|04:19:22.616] --------------------------------------------------------------------------------------------------------------------------------------------------------- 
geth-1  | INFO [02-22|04:19:22.616] Chain ID:  8453 (Base) 
geth-1  | INFO [02-22|04:19:22.616] Consensus: Optimism 
geth-1  | INFO [02-22|04:19:22.616]  


```