### PR TITLE
fix(node): Return correct version information

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
 
 RUN cd op-node && \
-    make op-node
+    make VERSION=$VERSION op-node
 
 FROM golang:1.21 as geth
 


### PR DESCRIPTION
### Description
Specify the version when building op-node, this 

```
# Before
❯ curl -X POST -H "Content-Type: application/json" --data \
    '{"jsonrpc":"2.0","method":"optimism_version","params":[],"id":1}' \
    http://localhost:7545
{"jsonrpc":"2.0","id":1,"result":"v0.0.0-"}

# After
❯ curl -X POST -H "Content-Type: application/json" --data \
    '{"jsonrpc":"2.0","method":"optimism_version","params":[],"id":1}' \
    http://localhost:7545
{"jsonrpc":"2.0","id":1,"result":"v1.5.1-"}
```