### PR TITLE
added stopwaitsecs value of 300 seconds to supervisord programs

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -8,9 +8,11 @@ command=/app/op-node-entrypoint
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 redirect_stderr=true
+stopwaitsecs=300
 
 [program:op-geth]
 command=/app/geth-entrypoint
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 redirect_stderr=true
+stopwaitsecs=300


### PR DESCRIPTION
In order to stop and resume pruned nodes with supervisord, geth needs more time to gracefully shut down. We can achieve this be setting `stopwaitsecs` in the `supervisord.conf` file. 

If a value for `stopwaitsecs` isn't provided, the default value is 10 seconds. After this time has elapsed, supervisord will send a `SIGKILL` to any remaining child processes. For nodes that have synced a few million blocks, 10 seconds is not enough time for flushing to disk, and geth is stopped with `SIGKILL`. This results in incomplete/corrupt data, and the node will have to rewind and resync (often from genesis) when resumed. Increasing `stopwaitsecs` solves this issue by giving the appropriate amount of time for the blockchain to flush to disk before stopping. This will not increase the amount of time it takes to successfully stop a node, as supervisord doesn't wait the full duration once `SIGCHLD` is received. 