### PR TITLE
[Chore] Add OP_NODE_SYNCMODE

### DIFF
--- a/.env.mainnet
+++ b/.env.mainnet
@@ -33,6 +33,7 @@ OP_NODE_RPC_PORT=8545
 OP_NODE_SNAPSHOT_LOG=/tmp/op-node-snapshot-log
 OP_NODE_VERIFIER_L1_CONFS=4
 OP_NODE_ROLLUP_LOAD_PROTOCOL_VERSIONS=true
+OP_NODE_SYNCMODE=execution-layer
 
 # OP_NODE_L1_TRUST_RPC allows for faster syncing, but should be used *only* if your L1 RPC node
 # is fully trusted. It also allows op-node to work with clients such as Erigon that do not

--- a/.env.sepolia
+++ b/.env.sepolia
@@ -33,6 +33,7 @@ OP_NODE_RPC_PORT=8545
 OP_NODE_SNAPSHOT_LOG=/tmp/op-node-snapshot-log
 OP_NODE_VERIFIER_L1_CONFS=4
 OP_NODE_ROLLUP_LOAD_PROTOCOL_VERSIONS=true
+OP_NODE_SYNCMODE=execution-layer
 
 # OP_NODE_L1_TRUST_RPC allows for faster syncing, but should be used *only* if your L1 RPC node
 # is fully trusted. It also allows op-node to work with clients such as Erigon that do not


### PR DESCRIPTION
To enable op-geth snapsync, it will be required to set the syncmode to `execution-layer`