### PR TITLE
add flag to disable tx gossip

### DIFF
--- a/geth-entrypoint
+++ b/geth-entrypoint
@@ -67,4 +67,5 @@ exec ./geth \
     --rollup.halt=major \
     --op-network="$OP_NODE_NETWORK" \
     --port="$P2P_PORT" \
+    --rollup.disabletxpoolgossip=true \
     $ADDITIONAL_ARGS # intentionally unquoted


### PR DESCRIPTION
no reason for standard nodes to be gossiping txs so add flag to disable it by default.