### PR TITLE
docs(.env.*): Uncomment OP_NODE_L1_BEACON (required)

### DIFF
--- a/.env.mainnet
+++ b/.env.mainnet
@@ -8,7 +8,7 @@ OP_GETH_SEQUENCER_HTTP=https://mainnet-sequencer.base.org
 OP_NODE_L1_ETH_RPC=https://1rpc.io/eth
 
 # [required] replace with your preferred L1 CL beacon endpoint:
-# OP_NODE_L1_BEACON=https://your.mainnet.beacon.node/endpoint-here
+OP_NODE_L1_BEACON=https://your.mainnet.beacon.node/endpoint-here
 
 # auth secret used by op-geth engine API:
 OP_NODE_L2_ENGINE_AUTH_RAW=688f5d737bad920bdfb2fc2f488d6b6209eebda1dae949a8de91398d932c517a

--- a/.env.sepolia
+++ b/.env.sepolia
@@ -8,7 +8,7 @@ OP_GETH_SEQUENCER_HTTP=https://sepolia-sequencer.base.org
 OP_NODE_L1_ETH_RPC=https://rpc.sepolia.org
 
 # [required] replace with your preferred L1 CL beacon endpoint:
-# OP_NODE_L1_BEACON=https://your.sepolia.beacon.node/endpoint-here
+OP_NODE_L1_BEACON=https://your.sepolia.beacon.node/endpoint-here
 
 # auth secret used by op-geth engine API:
 OP_NODE_L2_ENGINE_AUTH_RAW=688f5d737bad920bdfb2fc2f488d6b6209eebda1dae949a8de91398d932c517a


### PR DESCRIPTION
Uncommented OP_NODE_L1_BEACON since it's required; we are seeing instances where people are forgetting to do this and are reporting it as an issue in the Discord (not realizing not uncommenting the line after adding the endpoint was the problem).