### PR TITLE
Update Reth for Fjord CL Support

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,8 +55,6 @@ jobs:
         include:
           - arch: linux/amd64
             features: jemalloc,asm-keccak,optimism
-          - arch: linux/arm64
-            features: jemalloc,optimism
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -14,7 +14,7 @@ RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
 RUN cd op-node && \
     make VERSION=$VERSION op-node
 
-FROM rust:1.78 AS reth
+FROM rust:1.79 AS reth
 
 ARG FEATURES=jemalloc,asm-keccak,optimism
 
@@ -23,7 +23,7 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV COMMIT=e5111f03396f661bdff69d04047d0c076bad75f3
+ENV COMMIT=7d55a14b1fca006260737dec1f9d3e93cd4c2008
 
 RUN git clone $REPO . && git checkout $COMMIT
 RUN cargo build --bin op-reth --locked --features $FEATURES --profile maxperf


### PR DESCRIPTION
### Description
This PR contains two small Reth fixes:

1. The current version of Reth we're using cannot consensus sync Fjord blocks with user transactions. This PR updates the commit to include the fix made [here](https://github.com/paradigmxyz/reth/pull/8906).
2. The current docker GH actions setup is misconfigured and overwriting the manifest. This PR removes the arm build for now and we'll re-add it following this [pattern](https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners).


