### PR TITLE
op-node: v1.7.7 / op-geth: v1.101315.2 / op-reth: v1.0.0-rc.2

### DIFF
--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -3,10 +3,8 @@ FROM golang:1.21 as op
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.7.6
-# for verification:
-ENV COMMIT=4a487b8920daa9dc4b496d691d5f283f9bb659b1
-
+ENV VERSION=v1.7.7
+ENV COMMIT=f8143c8cbc4cc0c83922c53f17a1e47280673485
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
@@ -19,11 +17,8 @@ FROM golang:1.21 as geth
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/op-geth.git
-ENV VERSION=v1.101315.1
-# for verification:
-ENV COMMIT=3fbae78d638d1b903e702a14f98644c1103ae1b3
-
-# avoid depth=1, so the geth build can read tags
+ENV VERSION=v1.101315.2
+ENV COMMIT=7c2819836018bfe0ca07c4e4955754834ffad4e0
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -3,10 +3,8 @@ FROM golang:1.21 AS op
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.7.6
-# for verification:
-ENV COMMIT=4a487b8920daa9dc4b496d691d5f283f9bb659b1
-
+ENV VERSION=v1.7.7
+ENV COMMIT=f8143c8cbc4cc0c83922c53f17a1e47280673485
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
@@ -23,9 +21,12 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV COMMIT=7d55a14b1fca006260737dec1f9d3e93cd4c2008
+ENV VERSION=v1.0.0-rc.2
+ENV COMMIT=d786b459d93a6e1f7cf903a37f0542aafd671e7f
+RUN git clone $REPO --branch $VERSION --single-branch . && \
+    git switch -c branch-$VERSION && \
+    bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
 
-RUN git clone $REPO . && git checkout $COMMIT
 RUN cargo build --bin op-reth --locked --features $FEATURES --profile maxperf
 
 FROM ubuntu:22.04


### PR DESCRIPTION
### Description
Update op-node / op-geth and op-reth to versions that contain the optimistic Fjord mainnet activation date.