### PR TITLE
fix: typo in natextip for op-geth

### DIFF
--- a/geth/geth-entrypoint
+++ b/geth/geth-entrypoint
@@ -38,7 +38,7 @@ if [ "${OP_GETH_BOOTNODES+x}" = x ]; then
     ADDITIONAL_ARGS="$ADDITIONAL_ARGS --bootnodes=$OP_GETH_BOOTNODES"
 fi
 
-if [ "${HOST_IP:+x}" = x]; then
+if [ "${HOST_IP:+x}" = x ]; then
 	ADDITIONAL_ARGS="$ADDITIONAL_ARGS --nat=extip:$HOST_IP"
 fi 
 


### PR DESCRIPTION
### Description
Fix typo in geth-entrypoint for the if statement starting up op-geth. This is a reopened version of this [PR](https://github.com/base-org/node/pull/280).
