### PR TITLE
Update Reth to commit that supports CL sync

### DIFF
--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -20,12 +20,10 @@ WORKDIR /app
 
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
-ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV VERSION=v1.0.0-rc.2
-ENV COMMIT=d786b459d93a6e1f7cf903a37f0542aafd671e7f
-RUN git clone $REPO --branch $VERSION --single-branch . && \
-    git switch -c branch-$VERSION && \
-    bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
+#TODO: Revert to upstream, once https://github.com/paradigmxyz/reth/pull/9105 is merged.
+ENV REPO=https://github.com/danyalprout/reth.git
+ENV COMMIT=c79cbf4a918480556bd37204942a2d69827fed9f
+RUN git clone $REPO . && git checkout $COMMIT
 
 RUN cargo build --bin op-reth --locked --features $FEATURES --profile maxperf
 


### PR DESCRIPTION
### Description
 Update our Reth version to temporarily include https://github.com/paradigmxyz/reth/pull/9105. This change allows CL sync to work fully and will unblock our snapshot infrastructure.

It has the side effect that EL sync will be disabled after the initial sync (until https://github.com/ethereum-optimism/optimism/pull/10767 is merged). 