### PR TITLE
chore: remove unused env vars

### DIFF
--- a/.env.mainnet
+++ b/.env.mainnet
@@ -1,8 +1,7 @@
 RETH_CHAIN=base
 RETH_SEQUENCER_HTTP=https://mainnet-sequencer.base.org
-
-OP_GETH_GENESIS_FILE_PATH=mainnet/genesis-l2.json
 OP_GETH_SEQUENCER_HTTP=https://mainnet-sequencer.base.org
+
 # [optional] used to enable geth stats:
 # OP_GETH_ETH_STATS=nodename:secret@host:port
 

--- a/.env.sepolia
+++ b/.env.sepolia
@@ -1,7 +1,5 @@
 RETH_CHAIN=base-sepolia
 RETH_SEQUENCER_HTTP=https://sepolia-sequencer.base.org
-
-OP_GETH_GENESIS_FILE_PATH=sepolia/genesis-l2.json
 OP_GETH_SEQUENCER_HTTP=https://sepolia-sequencer.base.org
 
 # [optional] used to enable geth stats:

--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21 as op
+FROM golang:1.21 AS op
 
 WORKDIR /app
 
@@ -12,7 +12,7 @@ RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
 RUN cd op-node && \
     make VERSION=$VERSION op-node
 
-FROM golang:1.21 as geth
+FROM golang:1.21 AS geth
 
 WORKDIR /app
 


### PR DESCRIPTION
### Description
Remove the unused genesis file env vars. This was raised in https://github.com/base-org/node/issues/283. Our current image setup uses the superchain config.