### PR TITLE
Update op-node to 1.9.0 and op-geth to v1.101315.3

### DIFF
--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -3,8 +3,8 @@ FROM golang:1.21 AS op
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.7.7
-ENV COMMIT=f8143c8cbc4cc0c83922c53f17a1e47280673485
+ENV VERSION=v1.9.0
+ENV COMMIT=ec45f6634ab2855a4ae5d30c4e240d79f081d689
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
@@ -17,8 +17,8 @@ FROM golang:1.21 AS geth
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/op-geth.git
-ENV VERSION=v1.101315.2
-ENV COMMIT=7c2819836018bfe0ca07c4e4955754834ffad4e0
+ENV VERSION=v1.101315.3
+ENV COMMIT=8af19cf20261c0b62f98cc27da3a268f542822ee
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
**For Geth Nodes only**  Reth support for op 1.9.0 is in progress.

This PR bumps:
op-node to v1.9.0
op-geth to v1.101315.3

These changes are required to run Base nodes using Geth after the Granite hard fork 