### PR TITLE
chore: update reth (v1.0.5), op-node (v1.9.0)

### DIFF
--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -12,7 +12,7 @@ RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
 RUN cd op-node && \
     make VERSION=$VERSION op-node
 
-FROM rust:1.79 AS reth
+FROM rust:1.80 AS reth
 
 ARG FEATURES=jemalloc,asm-keccak,optimism
 

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -3,8 +3,8 @@ FROM golang:1.21 AS op
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.7.7
-ENV COMMIT=f8143c8cbc4cc0c83922c53f17a1e47280673485
+ENV VERSION=v1.9.0
+ENV COMMIT=ec45f6634ab2855a4ae5d30c4e240d79f081d689
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
@@ -21,7 +21,7 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV COMMIT=29dc8fc05f74111c9ff67ddcd03638ee081b1dc0
+ENV COMMIT=ffd71a0b024e6c20f15cb95bcdf1b4882fc91093
 RUN git clone $REPO . && git checkout $COMMIT
 
 RUN cargo build --bin op-reth --locked --features $FEATURES --profile maxperf


### PR DESCRIPTION
### Description
Update the reth/op-node combo to support base sepolia granite hardfork.