### PR TITLE
Upgrade to op-node 1.9.1

### DIFF
--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -3,8 +3,8 @@ FROM golang:1.21 AS op
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.9.0
-ENV COMMIT=ec45f6634ab2855a4ae5d30c4e240d79f081d689
+ENV VERSION=v1.9.1
+ENV COMMIT=4797ddb70e05d4952685bad53e608cb5606284e6
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
@@ -17,8 +17,8 @@ FROM golang:1.21 AS geth
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/op-geth.git
-ENV VERSION=v1.101315.3
-ENV COMMIT=8af19cf20261c0b62f98cc27da3a268f542822ee
+ENV VERSION=v1.101408.0
+ENV COMMIT=5c2e75862239c77d2873de1888ba52ee84c83178
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -3,8 +3,8 @@ FROM golang:1.21 AS op
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.9.0
-ENV COMMIT=ec45f6634ab2855a4ae5d30c4e240d79f081d689
+ENV VERSION=v1.9.1
+ENV COMMIT=4797ddb70e05d4952685bad53e608cb5606284e6
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
@@ -21,7 +21,7 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV COMMIT=ffd71a0b024e6c20f15cb95bcdf1b4882fc91093
+ENV COMMIT=c228fe15808c3acbf18dc3af1a03ef5cbdcda07a
 RUN git clone $REPO . && git checkout $COMMIT
 
 RUN cargo build --bin op-reth --locked --features $FEATURES --profile maxperf


### PR DESCRIPTION
Upgrades op-node dependency to 1.9.1. This is required for mainnet activation of the Granite hard fork on September 10th. Also includes the corresponding op-geth release, and bumps reth to latest. 