### PR TITLE
Allow execution nodes to act as peers for other nodes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - "8545:8545"       # RPC
       - "8546:8546"       # websocket
       - "7301:6060"       # metrics
+      - "30303:30303"     # P2P TCP
+      - "30303:30303/udp" # P2P UDP
     command: [ "bash", "./execution-entrypoint" ]
     volumes:
         - ${HOST_DATA_DIR}:/data


### PR DESCRIPTION
Inbound peering ports for EL nodes is currently blocked so they cannot act as peers for the rest of the Base network