### PR TITLE
Remove reth arm64 build

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,8 +31,6 @@ jobs:
         include:
           - arch: linux/amd64
             features: jemalloc,asm-keccak,optimism
-          - arch: linux/arm64
-            features: jemalloc,optimism
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
It's running out of memory, and not built as part of the docker build anyway.