### PR TITLE
Avoid redundant `git switch` in Dockerfile for cleaner and more effic…

### DIFF
--- a/nethermind/Dockerfile
+++ b/nethermind/Dockerfile
@@ -5,11 +5,9 @@ WORKDIR /app
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
 ENV VERSION=v1.9.1
 ENV COMMIT=4797ddb70e05d4952685bad53e608cb5606284e6
-RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
-    git switch -c branch-$VERSION && \
-    bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
-
-RUN cd op-node && \
+RUN git clone --depth 1 $REPO --branch op-node/$VERSION --single-branch . && \
+    git checkout $COMMIT && \
+    cd op-node && \
     make VERSION=$VERSION op-node
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0.403-noble AS build
@@ -22,9 +20,9 @@ WORKDIR /app
 ENV REPO=https://github.com/NethermindEth/nethermind.git
 ENV VERSION=1.29.1
 ENV COMMIT=dfea52404006c6ce1b133b98f324dbfcb62773e1
-RUN git clone $REPO --branch $VERSION --single-branch . && \
-    git switch -c $VERSION 
-RUN bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
+RUN git clone --depth 1 $REPO --branch $VERSION --single-branch . && \
+    git checkout $COMMIT
+    
 RUN TARGETARCH=${TARGETARCH#linux/} && \
     arch=$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH") && \
     echo "Using architecture: $arch" && \

--- a/nethermind/Dockerfile
+++ b/nethermind/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
 ENV VERSION=v1.9.1
 ENV COMMIT=4797ddb70e05d4952685bad53e608cb5606284e6
-RUN git clone --depth 1 $REPO --branch op-node/$VERSION --single-branch . && \
+RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git checkout $COMMIT && \
     cd op-node && \
     make VERSION=$VERSION op-node
@@ -20,7 +20,7 @@ WORKDIR /app
 ENV REPO=https://github.com/NethermindEth/nethermind.git
 ENV VERSION=1.29.1
 ENV COMMIT=dfea52404006c6ce1b133b98f324dbfcb62773e1
-RUN git clone --depth 1 $REPO --branch $VERSION --single-branch . && \
+RUN git clone $REPO --branch $VERSION --single-branch . && \
     git checkout $COMMIT
     
 RUN TARGETARCH=${TARGETARCH#linux/} && \


### PR DESCRIPTION
…ient git checkout

The original Dockerfile included a git switch command after cloning the repository, which was redundant since the commit hash could be checked out directly after the clone. This update removes the unnecessary git switch and performs the commit checkout directly with git checkout $COMMIT. This reduces the complexity of the build process and improves clarity.

Summary of Update:

1. Removed the redundant git switch in the op-node build stage.
2. Directly checked out the commit using git checkout $COMMIT after cloning.