### PR TITLE
Upgrade op-node (v1.9.5), op-geth (v1.101411.1), op-reth (v1.1.1)

### DIFF
--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -3,8 +3,8 @@ FROM golang:1.22 AS op
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.9.4
-ENV COMMIT=2c24e652161187f3e30045eac1e176e6b53c469d
+ENV VERSION=v1.9.5
+ENV COMMIT=5662448279e4fb16e073e00baeb6e458b12a59b2
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
@@ -17,8 +17,8 @@ FROM golang:1.22 AS geth
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/op-geth.git
-ENV VERSION=v1.101411.0
-ENV COMMIT=d5a96613c22bc46238a21d6c0f805399c26c9d4c
+ENV VERSION=v1.101411.1
+ENV COMMIT=4539f2d3a77f14bdad362c24e3773dc6aad87d5b
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -3,8 +3,8 @@ FROM golang:1.22 AS op
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.9.4
-ENV COMMIT=2c24e652161187f3e30045eac1e176e6b53c469d
+ENV VERSION=v1.9.5
+ENV COMMIT=5662448279e4fb16e073e00baeb6e458b12a59b2
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
@@ -21,8 +21,8 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV VERSION=v1.1.0
-ENV COMMIT=1ba631ba9581973e7c6cadeea92cfe1802aceb4a
+ENV VERSION=v1.1.1
+ENV COMMIT=15c230bac20e2b1b3532c8b0d470e815fbc0cc22
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
Upgrades to the latest releases of op-node, op-geth, and reth: 

Update to the latest releases
https://github.com/ethereum-optimism/optimism/releases/tag/v1.9.5
https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101411.1
https://github.com/paradigmxyz/reth/releases/tag/v1.1.1