### PR TITLE
Upgrade op-node(v1.10.0), op-geth(v1.101411.2), and op-reth(v1.1.2)

### DIFF
--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -3,8 +3,8 @@ FROM golang:1.22 AS op
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.9.5
-ENV COMMIT=5662448279e4fb16e073e00baeb6e458b12a59b2
+ENV VERSION=v1.10.0
+ENV COMMIT=910c9ade39c0bcdff5f2badd94efbe016a428e73
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
@@ -17,8 +17,8 @@ FROM golang:1.22 AS geth
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/op-geth.git
-ENV VERSION=v1.101411.1
-ENV COMMIT=4539f2d3a77f14bdad362c24e3773dc6aad87d5b
+ENV VERSION=v1.101411.2
+ENV COMMIT=3dd9b0274bae3d3d2c80ef517563a360108e8cf6
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -3,8 +3,8 @@ FROM golang:1.22 AS op
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.9.5
-ENV COMMIT=5662448279e4fb16e073e00baeb6e458b12a59b2
+ENV VERSION=v1.10.0
+ENV COMMIT=910c9ade39c0bcdff5f2badd94efbe016a428e73
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
@@ -21,8 +21,8 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV VERSION=v1.1.1
-ENV COMMIT=15c230bac20e2b1b3532c8b0d470e815fbc0cc22
+ENV VERSION=v1.1.2
+ENV COMMIT=496bf0bf715f0a1fafc198f8d72ccd71913d1a40
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
Adds required changes for the Holocene upgrade on Sepolia: 

* op-node to v1.10.0
* op-geth to v1.101411.2
* op-reth to v1.1.2