### PR TITLE
docs: Fix Typo Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ We recommend you have this hardware configuration to run a node:
 - a locally attached NVMe SSD drive
 - adequate storage capacity to accommodate both the snapshot restoration process (if restoring from snapshot) and chain data, ensuring a minimum of (2 \* current_chain_size) + snapshot_size + 20%\_buffer
 
-**Note:** If utilizing Amazon Elastic Block Store (EBS), ensure timing buffered disk reads are fast enough in order to avoid latency issues alongside the rate of new blocks added to Base during the initial synchronization process; `io2 block express` is recommended.
+**Note:** If utilizing Amazon Elastic Block Store (EBS), ensure time-buffered disk reads are fast enough in order to avoid latency issues alongside the rate of new blocks added to Base during the initial synchronization process; `io2 block express` is recommended.
 
 ### Troubleshooting
 


### PR DESCRIPTION
**Description**

I noticed a small issue with the wording in the documentation where "timing buffered disk reads" was used. This phrase seems to be a typo, as the correct term in the context of disk read operations should be "time-buffered disk reads."

The term "time-buffered" is commonly used in technical contexts related to disk I/O operations, and correcting this will help ensure clarity and accuracy. 

Thank you for reviewing this!
**Based.**