### PR TITLE
docs: Fix minor typo in security doc Update SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,7 +22,7 @@ platform.
 The HackerOne platform allows us to have a centralized and single reporting
 source for us to deliver optimized SLA's and results. All reports submitted to
 the platform are triaged around the clock by our team of Coinbase engineers
-with domain knowledge, assuring the best quality of review.
+with domain knowledge, assuring the best quality reviews.
 
 For more information on reporting vulnerabilities and our HackerOne bug bounty
 program, view our [security program policies][7].


### PR DESCRIPTION
I noticed a issue in the security documentation where the phrase "assuring the best quality of review" was used.
It seems that the singular "review" doesn’t quite fit the context, as we’re referring to multiple reports being reviewed.

I’ve corrected this to "assuring the best quality **reviews**," which is more appropriate when discussing the evaluation of multiple reports.

Love you! Based.
