### PR TITLE
Update op-geth to v1.101411.6

### DIFF
--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -20,8 +20,8 @@ FROM golang:1.22 AS geth
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/op-geth.git
-ENV VERSION=v1.101411.4
-ENV COMMIT=efa05b1bf5c22a60745e638ad9d4adadfe3daba9
+ENV VERSION=v1.101411.6
+ENV COMMIT=50b3422b9ac682a8fa503c4f409339a9bff69717
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
This change updates op-geth to `v1.101411.6` to include https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101411.6