### PR TITLE
Remove unnecessary NETWORK_ENV variable from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     environment:
       - NODE_TYPE=${NODE_TYPE:-vanilla}
     env_file:
-      - ${NETWORK_ENV:-.env.mainnet} # Use .env.mainnet by default, override with .env.sepolia for testnet
+      - .env.mainnet
   node:
     build:
       context: .
@@ -30,4 +30,4 @@ services:
       - "6060:6060" # pprof
     command: ["bash", "./op-node-entrypoint"]
     env_file:
-      - ${NETWORK_ENV:-.env.mainnet} # Use .env.mainnet by default, override with .env.sepolia for testnet
+      - .env.mainnet


### PR DESCRIPTION
Replaced the use of the NETWORK_ENV environment variable with a direct reference to .env.mainnet in the env_file section for both services. This simplifies the configuration and removes unnecessary indirection. To switch networks, manually change the env_file as needed.