### PR TITLE
fix: correct JSON tags in Info struct

### DIFF
--- a/dependency_updater/dependency_updater.go
+++ b/dependency_updater/dependency_updater.go
@@ -21,8 +21,8 @@ type Info struct {
 	Tag       string `json:"tag"`
 	Commit    string `json:"commit"`
 	TagPrefix string `json:"tagPrefix,omitempty"`
-	Owner     string `json:"owner`
-	Repo      string `json:"repo`
+	Owner     string `json:"owner"`
+	Repo      string `json:"repo"`
 }
 
 type VersionUpdateInfo struct {


### PR DESCRIPTION
Fixed missing closing quotes in Owner and Repo JSON tags in the Info struct.