### PR TITLE
Restart unless stopped

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     build:
       context: .
       dockerfile: ${CLIENT:-geth}/Dockerfile
+    restart: unless-stopped
     ports:
       - "8545:8545" # RPC
       - "8546:8546" # websocket
@@ -20,6 +21,7 @@ services:
     build:
       context: .
       dockerfile: ${CLIENT:-geth}/Dockerfile
+    restart: unless-stopped
     depends_on:
       - execution
     ports:


### PR DESCRIPTION
`restart: unless-stopped` is a good practice in production-like environments (and most of the non-production systems).

It improves resilience (containers will restart if node is rebooted or if one of the containers gets killed by OOM); it also helps with predictibility as it won't restart the containers if we intentionally stopped them.