### PR TITLE
docs: fix unclosed parenthesis in storage requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Base is a secure, low-cost, developer-friendly Ethereum L2 built on Optimism's [
 - Modern Multicore CPU
 - 32GB RAM (64GB Recommended)
 - NVMe SSD drive
-- Storage: (2 \* [current chain size](https://base.org/stats) + [snapshot size](https://basechaindata.vercel.app) + 20% buffer (to accommodate future growth)
+- Storage: (2 \* [current chain size](https://base.org/stats) + [snapshot size](https://basechaindata.vercel.app) + 20% buffer) (to accommodate future growth)
 - Docker and Docker Compose
 
 ### Production Hardware Specifications


### PR DESCRIPTION
Fixed missing closing parenthesis in the storage calculation formula in the hardware requirements section. The formula was missing a closing parenthesis after "20% buffer", causing incorrect markdown formatting