### PR TITLE
Fix apt cache cleanup in nethermind Dockerfile

### DIFF
--- a/nethermind/Dockerfile
+++ b/nethermind/Dockerfile
@@ -35,7 +35,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:9.0-noble
 
 RUN apt-get update && \
     apt-get install -y jq curl supervisor && \
-    rm -rf /var/lib/apt/lists
+    rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /var/log/supervisor
 


### PR DESCRIPTION
Add missing `/*` to `rm -rf /var/lib/apt/lists/*` command to properly clean apt cache and reduce image size