### PR TITLE
fix: env vars in v3

### DIFF
--- a/dependency_updater/dependency_updater.go
+++ b/dependency_updater/dependency_updater.go
@@ -44,7 +44,7 @@ func main() {
 			&cli.StringFlag{
 				Name:     "token",
 				Usage:    "Auth token used to make requests to the Github API must be set using export",
-				Sources:  cli.EnvVars("GITHUB_TOKEN"),
+				EnvVars: []string{"GITHUB_TOKEN"},
 				Required: true,
 			},
 			&cli.StringFlag{


### PR DESCRIPTION
v3 uses `EnvVars` (list of strings) instead of `Sources`.
updated the code so env vars are handled correctly now.