### PR TITLE
fix GitHub markdown syntax for NOTE block in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The following are the hardware specifications we use in production:
 - **Storage**: RAID 0 of all local NVMe drives (`/dev/nvme*`)
 - **Filesystem**: ext4
 
-[!NOTE]
+> [!NOTE]
 To run the node using a supported client, you can use the following command:
 `CLIENT=supported_client docker compose up --build`
  


### PR DESCRIPTION
Correct NOTE callout syntax from `[!NOTE]` to `> [!NOTE]` to properly display the alert block in GitHub markdown. The current syntax doesn't render as an alert block, while the corrected syntax will display a properly formatted note callout