### PR TITLE
chore(dependency-updater): polish JSON unmarshal error message

### DIFF
--- a/dependency_updater/dependency_updater.go
+++ b/dependency_updater/dependency_updater.go
@@ -92,7 +92,7 @@ func updater(token string, repoPath string, commit bool, githubAction bool) erro
 
 	err = json.Unmarshal(f, &dependencies)
 	if err != nil {
-		return fmt.Errorf("error unmarshaling versions JSON to dependencies: %s", err)
+		return fmt.Errorf("error unmarshalling versions JSON to dependencies: %s", err)
 	}
 
 	for dependency := range dependencies {


### PR DESCRIPTION


### Description
- **What**: Fix spelling in error string (`unmarshaling` → `unmarshalling`) in `dependency_updater.go`.
