### PR TITLE
Remove redundant !githubAction check in else if statement.

### DIFF
--- a/dependency_updater/dependency_updater.go
+++ b/dependency_updater/dependency_updater.go
@@ -149,7 +149,7 @@ func createCommitMessage(updatedDependencies []VersionUpdateInfo, repoPath strin
 		if err != nil {
 			return fmt.Errorf("error creating git commit message: %s", err)
 		}
-	} else if !githubAction {
+	} else {
 		cmd := exec.Command("git", "commit", "-am", commitTitle, "-m", commitDescription)
 		if err := cmd.Run(); err != nil {
 			return fmt.Errorf("failed to run git commit -m: %s", err)


### PR DESCRIPTION
After `if githubAction`, the else block guarantees githubAction is false, making the explicit !githubAction condition unnecessary