### PR TITLE
Fix apt cache cleanup in reth Dockerfile

### DIFF
--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -47,7 +47,7 @@ FROM ubuntu:22.04
 
 RUN apt-get update && \
     apt-get install -y jq curl supervisor && \
-    rm -rf /var/lib/apt/lists
+    rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /var/log/supervisor
 
 WORKDIR /app


### PR DESCRIPTION
Add missing wildcard to rm command for proper cleanup of apt package lists.