### PR TITLE
fix(nethermind): validate OP_NODE_NETWORK in entrypoint

### DIFF
--- a/nethermind/nethermind-entrypoint
+++ b/nethermind/nethermind-entrypoint
@@ -4,7 +4,6 @@ set -eu
 # Default configurations
 NETHERMIND_DATA_DIR=${NETHERMIND_DATA_DIR:-/data}
 NETHERMIND_LOG_LEVEL=${NETHERMIND_LOG_LEVEL:-Info}
-NETWORK=${NETWORK:-mainnet}
 
 RPC_PORT="${RPC_PORT:-8545}"
 WS_PORT="${WS_PORT:-8546}"
@@ -16,8 +15,8 @@ JWT_SECRET_FILE=${JWT_SECRET_FILE:-/tmp/jwt/jwtsecret}
 ADDITIONAL_ARGS=""
 
 # Check if required variables are set
-if [[ -z "$NETWORK" ]]; then
-    echo "Expected NETWORK to be set" 1>&2
+if [[ -z "$OP_NODE_NETWORK" ]]; then
+    echo "Expected OP_NODE_NETWORK to be set" 1>&2
     exit 1
 fi
 


### PR DESCRIPTION
## Description
Replace unused NETWORK check to match --config="$OP_NODE_NETWORK".
Prevents false exits; no behavior change for correct configs. Verified with/without OP_NODE_NETWORK.