### PR TITLE
fix: correct inconsistency at .env.sepolia

### DIFF
--- a/.env.sepolia
+++ b/.env.sepolia
@@ -50,7 +50,7 @@ OP_NODE_P2P_BOOTNODES=enr:-J24QNz9lbrKbN4iSmmjtnr7SjUMk4zB7f1krHZcTZx-JRKZd0kA2g
 # ----------------
 OP_RETH_DISABLE_DISCOVERY="false"
 OP_RETH_DISABLE_TX_POOL_GOSSIP="true"
-OP_RETH_OP_NETWORK="base"
+OP_RETH_OP_NETWORK="base-sepolia"
 
 # RPC CONFIGURATION
 # ---------------


### PR DESCRIPTION
Updated `OP_RETH_OP_NETWORK` from "base" to "base-sepolia"

This maintains consistency with other sepolia-related variables:
`RETH_CHAIN=base-sepolia`
`OP_NODE_NETWORK=base-sepolia`
`OP_GETH_OP_NETWORK=base-sepolia`