### PR TITLE
Update OP_GETH version to v1.101603.1-rc.1

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -1,12 +1,12 @@
-export BASE_RETH_NODE_COMMIT=6bd19d5c2076bd47093ed9d1fdb684dc5757d7b2
+lmaolmaexport BASE_RETH_NODE_COMMIT=6bd19d5c2076bd47093ed9d1fdb684dc5757d7b2
 export BASE_RETH_NODE_REPO=https://github.com/base/node-reth.git
 export BASE_RETH_NODE_TAG=v0.1.8
 export NETHERMIND_COMMIT=100632d4415d08926c829d6329dd2ce7690d12d2
 export NETHERMIND_REPO=https://github.com/NethermindEth/nethermind.git
 export NETHERMIND_TAG=1.34.0
-export OP_GETH_COMMIT=b51c72ebea9dcf14e6859b14e4bd92c484714f08
+export OP_GETH_COMMIT=8da5bf0814d7206ee75bb88c90fb64fed4bc8e97
 export OP_GETH_REPO=https://github.com/ethereum-optimism/op-geth.git
-export OP_GETH_TAG=v1.101602.3
+export OP_GETH_TAG=v1.101603.1-rc.1
 export OP_NODE_COMMIT=b7b94b9ab904ab463e7a93d36ff4e99e6143d96b
 export OP_NODE_REPO=https://github.com/ethereum-optimism/optimism.git
 export OP_NODE_TAG=op-node/v1.13.7


### PR DESCRIPTION
Updated versions.env to use the latest OP_GETH_TAG (v1.101603.1-rc.1) and matching OP_GETH_COMMIT (8da5bf0814d7206ee75bb88c90fb64fed4bc8e97).
