### PR TITLE
dependency_updater: remove redundant string casts in updater CLI args

### DIFF
--- a/dependency_updater/dependency_updater.go
+++ b/dependency_updater/dependency_updater.go
@@ -64,7 +64,7 @@ func main() {
 			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			err := updater(string(cmd.String("token")), string(cmd.String("repo")), cmd.Bool("commit"), cmd.Bool("github-action"))
+			err := updater(cmd.String("token"), cmd.String("repo"), cmd.Bool("commit"), cmd.Bool("github-action"))
 			if err != nil {
 				return fmt.Errorf("failed to run updater: %s", err)
 			}


### PR DESCRIPTION
- Replace string(cmd.String("token")) and string(cmd.String("repo")) with direct cmd.String(...) calls
- No functional changes; improves clarity and avoids unnecessary casts