### PR TITLE
geth: respect HOST_IP env; remove override that broke --nat=extip

### DIFF
--- a/geth/geth-entrypoint
+++ b/geth/geth-entrypoint
@@ -7,7 +7,7 @@ RPC_PORT="${RPC_PORT:-8545}"
 WS_PORT="${WS_PORT:-8546}"
 AUTHRPC_PORT="${AUTHRPC_PORT:-8551}"
 METRICS_PORT="${METRICS_PORT:-6060}"
-HOST_IP="" # put your external IP address here and open port 30303 to improve peer connectivity
+# Set env HOST_IP to your external IP and open port 30303 to improve peer connectivity
 P2P_PORT="${P2P_PORT:-30303}"
 DISCOVERY_PORT="${DISCOVERY_PORT:-30303}"
 ADDITIONAL_ARGS=""


### PR DESCRIPTION
The entrypoint hard-set HOST_IP="" which overwrote any environment-provided value. As a result, the conditional that appends --nat=extip:$HOST_IP never executed, making it impossible to advertise a public IP even when HOST_IP was supplied via env. This fixes the issue by removing the overriding assignment and adding a clarifying comment to set HOST_IP via environment. Now, when HOST_IP is non-empty, --nat=extip is correctly applied; when unset/empty, it’s omitted.
