### PR TITLE
fix(dependency_updater): prevent infinite pagination loop by checking NextPage before advancing

### DIFF
--- a/dependency_updater/dependency_updater.go
+++ b/dependency_updater/dependency_updater.go
@@ -217,9 +217,10 @@ func getVersionAndCommit(ctx context.Context, client *github.Client, dependencie
 				if foundPrefixVersion {
 					break
 				}
+				if resp.NextPage == 0 {
+					break
+				}
 				options.Page = resp.NextPage
-			} else if resp.NextPage == 0 {
-				break
 			}
 		}
 	}


### PR DESCRIPTION
The previous pagination logic placed the `resp.NextPage == 0` check in an unreachable `else if` branch competing with TagPrefix conditions. As a result, when TagPrefix != "" and no matching release is found on the last page, the code set options.Page = 0 and could loop indefinitely.

This change:
- Moves the `resp.NextPage == 0` termination check to run before assigning `options.Page = resp.NextPage`.
- Removes the unreachable `else if resp.NextPage == 0` branch.

The new flow follows the official go-github pagination example pattern, ensuring the loop exits correctly and preventing infinite iteration.