### PR TITLE
Update Dockerfile

### DIFF
--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -29,7 +29,7 @@ FROM ubuntu:24.04
 
 RUN apt-get update && \
     apt-get install -y jq curl supervisor && \
-    rm -rf /var/lib/apt/lists
+    rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /var/log/supervisor
 
 WORKDIR /app


### PR DESCRIPTION
🧠 **What Changed**

The original command deleted the entire directory `/var/lib/apt/lists`. The fixed version deletes only its contents (`*`), keeping the directory itself.

⚠️ **Why It Matters**

`apt` expects `/var/lib/apt/lists/` to exist as a directory, even if empty.

If you remove the folder entirely, later `apt-get update` or similar commands can fail with:

```
E: The directory /var/lib/apt/lists/ partial is missing.
```

The correct approach is to clean out files using:

```bash
rm -rf /var/lib/apt/lists/*
```

✅ **Result**

✔ Keeps image clean (same effect — deletes cached list files). ✔ Maintains directory structure, so future `apt` operations won’t break. ✔ Standard best practice in Dockerfiles.