### PR TITLE
chore: add pruning snapshot capability

### DIFF
--- a/reth/reth-entrypoint
+++ b/reth/reth-entrypoint
@@ -32,6 +32,11 @@ else
     BINARY="./op-reth"
 fi
 
+# Add pruning for base
+if [[ "$NODE_TYPE" == "base" && -n "${RETH_PRUNING_ARGS+x}" = x ]]; then
+    ADDITIONAL_ARGS="$ADDITIONAL_ARGS $RETH_PRUNING_ARGS"
+fi
+
 mkdir -p "$RETH_DATA_DIR"
 echo "$OP_NODE_L2_ENGINE_AUTH_RAW" > "$OP_NODE_L2_ENGINE_AUTH"
 


### PR DESCRIPTION
## Overview

This PR adds flags to enable pruning for reth snapshots. 

`$RETH_PRUNING_ARGS` will populate as follows:

```
--prune.senderrecovery.distance=50000 --prune.transactionlookup.distance=50000 --prune.receipts.distance=50000 --prune.accounthistory.distance=50000 --prune.storagehistory.distance=50000 --prune.bodies.distance=50000
```

Reference: https://github.com/paradigmxyz/reth/blob/main/crates/node/core/src/args/pruning.rs#L31 

The `.distance` ensures that we keep the last 50001 blocks.