### PR TITLE
Сhore: only emit dependency commits when updates exist

### DIFF
--- a/dependency_updater/dependency_updater.go
+++ b/dependency_updater/dependency_updater.go
@@ -121,7 +121,7 @@ func updater(token string, repoPath string, commit bool, githubAction bool) erro
 		return fmt.Errorf("error creating versions.env: %s", e)
 	}
 
-	if (commit && updatedDependencies != nil) || (githubAction && updatedDependencies != nil) {
+	if (commit || githubAction) && len(updatedDependencies) > 0 {
 		err := createCommitMessage(updatedDependencies, repoPath, githubAction)
 		if err != nil {
 			return fmt.Errorf("error creating commit message: %s", err)


### PR DESCRIPTION
Сlarify the updater guard so commit/GitHub Action output happens only when an update was actually recorded prevent future regressions if the slice is preallocated but remains empty