### PR TITLE
chore: add `syncmode` and `l2.enginekind` for pruning

### DIFF
--- a/reth/reth-entrypoint
+++ b/reth/reth-entrypoint
@@ -38,6 +38,18 @@ if [[ "$NODE_TYPE" == "base" && "${RETH_PRUNING_ARGS+x}" = x ]]; then
     ADDITIONAL_ARGS="$ADDITIONAL_ARGS $RETH_PRUNING_ARGS"
 fi
 
+# Configure sync mode for pruning
+if [ "${RETH_SYNC_MODE+x}" = x ]; then
+    echo "Adding sync mode arguments: $RETH_SYNC_MODE"
+    ADDITIONAL_ARGS="$ADDITIONAL_ARGS --syncmode=$RETH_SYNC_MODE"
+fi
+
+# Configure engine kind for pruning
+if [ "${RETH_ENGINE_KIND+x}" = x ]; then
+    echo "Adding engine kind arguments: $RETH_ENGINE_KIND"
+    ADDITIONAL_ARGS="$ADDITIONAL_ARGS --l2.enginekind=$RETH_ENGINE_KIND"
+fi
+
 mkdir -p "$RETH_DATA_DIR"
 echo "$OP_NODE_L2_ENGINE_AUTH_RAW" > "$OP_NODE_L2_ENGINE_AUTH"
 


### PR DESCRIPTION
If set, adds [syncmode flag](https://github.com/ethereum-optimism/optimism/blob/develop/op-node/flags/flags.go#L112) and [l2.enginekind flag](https://github.com/ethereum-optimism/optimism/blob/develop/op-node/flags/flags.go#L198) to `ADDITIONAL_ARGS` which is useful for faster syncing from genesis for pruning.

Tested the shell conditional with a dummy script