### PR TITLE
Add developer feedback notes for Base node setup

### DIFF
--- a/developer-notes-on-base-node.md
+++ b/developer-notes-on-base-node.md
@@ -1,0 +1,44 @@
+# Developer Notes on Running a Base Node
+
+I’ve been exploring how the Base node interacts with the OP Stack and Ethereum settlement.  
+Below are some notes and thoughts that might help other builders or operators who want to better understand the setup.
+
+---
+
+### 1. Installation Process
+
+The setup process is straightforward but requires more context around dependencies.  
+It would be great to include a short list of verified Go and Docker versions known to work well.  
+A compatibility table could prevent sync issues during setup.
+
+---
+
+### 2. Configuration Details
+
+The configuration files are clean, but adding a section about tuning for performance would be helpful.  
+For example, caching parameters or log verbosity settings for different environments.  
+That small detail can make it easier for builders who maintain multiple nodes.
+
+---
+
+### 3. Error Handling
+
+Sometimes, the initial sync stops unexpectedly due to data validation mismatches.  
+A “common errors” section with quick fixes would improve the experience for new node operators.
+
+---
+
+### 4. Suggestions
+
+If possible, having a single CLI command for both installation and health-check (like `base-node check`) would make operations smoother.  
+It could verify environment variables, ports, and config files before running the node.
+
+---
+
+### Closing Thoughts
+
+Base node design reflects the overall ethos of the ecosystem — clean, modular, and transparent.  
+I’m leaving these notes to help future contributors get familiar faster and avoid repeating setup issues.  
+Every small documentation update or troubleshooting guide strengthens the network for everyone.
+
+> The easier it is to run a node, the stronger Base becomes.


### PR DESCRIPTION
Added developer notes that summarize common setup issues and possible improvements for Base node operation.  
This aims to support new builders and node operators joining the ecosystem.
