### PR TITLE
reth-entrypoint: set NODE_TYPE default to vanilla (OP Reth)

### DIFF
--- a/reth/reth-entrypoint
+++ b/reth/reth-entrypoint
@@ -10,7 +10,7 @@ METRICS_PORT="${METRICS_PORT:-6060}"
 DISCOVERY_PORT="${DISCOVERY_PORT:-30303}"
 P2P_PORT="${P2P_PORT:-30303}"
 ADDITIONAL_ARGS=""
-NODE_TYPE="${NODE_TYPE:-base}"
+NODE_TYPE="${NODE_TYPE:-vanilla}"
 
 if [[ -z "${RETH_CHAIN:-}" ]]; then
     echo "expected RETH_CHAIN to be set" 1>&2


### PR DESCRIPTION
Align the NODE_TYPE default with README and docker-compose. Previously, the script defaulted to base, causing standalone runs to unintentionally start Base mode. This change ensures OP Reth (vanilla) is the default unless explicitly overridden, matching documented behavior and compose defaults.