### PR TITLE
Add 60s graceful shutdown timeout to services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
       context: .
       dockerfile: ${CLIENT:-geth}/Dockerfile
     restart: unless-stopped
+    stop_grace_period: 60s
     ports:
       - "8545:8545" # RPC
       - "8546:8546" # websocket
@@ -20,6 +21,7 @@ services:
       context: .
       dockerfile: ${CLIENT:-geth}/Dockerfile
     restart: unless-stopped
+    stop_grace_period: 60s
     depends_on:
       - execution
     ports:


### PR DESCRIPTION
Set stop_grace_period: 60s for execution and op-node. Docker’s default 10s timeout can be too short for clean client shutdowns.