### PR TITLE
fix: resolve unreachable code and infinite loop in release pagination

### DIFF
--- a/dependency_updater/dependency_updater.go
+++ b/dependency_updater/dependency_updater.go
@@ -195,32 +195,33 @@ func getVersionAndCommit(ctx context.Context, client *github.Client, dependencie
 				return "", "", VersionUpdateInfo{}, fmt.Errorf("error getting releases: %s", err)
 			}
 
-			if dependencies[dependencyType].TagPrefix == "" {
-				version = releases[0]
-				if *version.TagName != dependencies[dependencyType].Tag {
-					diffUrl = generateGithubRepoUrl(dependencies, dependencyType) + "/compare/" +
-						dependencies[dependencyType].Tag + "..." + *version.TagName
-				}
-				break
-			} else if dependencies[dependencyType].TagPrefix != "" {
-				for release := range releases {
-					if strings.HasPrefix(*releases[release].TagName, dependencies[dependencyType].TagPrefix) {
-						version = releases[release]
-						foundPrefixVersion = true
-						if *version.TagName != dependencies[dependencyType].Tag {
-							diffUrl = generateGithubRepoUrl(dependencies, dependencyType) + "/compare/" +
-								dependencies[dependencyType].Tag + "..." + *version.TagName
-						}
-						break
+		if dependencies[dependencyType].TagPrefix == "" {
+			version = releases[0]
+			if *version.TagName != dependencies[dependencyType].Tag {
+				diffUrl = generateGithubRepoUrl(dependencies, dependencyType) + "/compare/" +
+					dependencies[dependencyType].Tag + "..." + *version.TagName
+			}
+			break
+		} else if dependencies[dependencyType].TagPrefix != "" {
+			for release := range releases {
+				if strings.HasPrefix(*releases[release].TagName, dependencies[dependencyType].TagPrefix) {
+					version = releases[release]
+					foundPrefixVersion = true
+					if *version.TagName != dependencies[dependencyType].Tag {
+						diffUrl = generateGithubRepoUrl(dependencies, dependencyType) + "/compare/" +
+							dependencies[dependencyType].Tag + "..." + *version.TagName
 					}
-				}
-				if foundPrefixVersion {
 					break
 				}
-				options.Page = resp.NextPage
-			} else if resp.NextPage == 0 {
+			}
+			if foundPrefixVersion {
 				break
 			}
+			if resp.NextPage == 0 {
+				break
+			}
+			options.Page = resp.NextPage
+		}
 		}
 	}
 


### PR DESCRIPTION
Fixed unreachable code that could cause infinite loop when searching for releases with specific tag prefixes.

What was wrong:
The code had an impossible condition - it checked if TagPrefix was empty, then if it wasn't empty, and then had a third check that could never run because the first two already covered everything.

This meant that when looking for a release with a specific prefix (like "op-node"), if that release didn't exist, the code would keep searching forever instead of stopping when it ran out of pages.

What changed:
Moved the "no more pages" check to where it actually makes sense - inside the prefix search logic. Now it properly stops when either finding the release or running out of pages to check.

Why it matters:
Prevents the dependency updater from getting stuck in an endless loop when a tagged release doesn't exist in a repository.