### PR TITLE
Add Flashblocks args without overwriting existing ADDITIONAL_ARGS

### DIFF
--- a/reth/reth-entrypoint
+++ b/reth/reth-entrypoint
@@ -19,7 +19,7 @@ fi
 
 # Enable Flashblocks support if websocket URL is provided
 if [[ -n "${RETH_FB_WEBSOCKET_URL:-}" ]]; then
-    ADDITIONAL_ARGS="--websocket-url=$RETH_FB_WEBSOCKET_URL"
+    ADDITIONAL_ARGS="$ADDITIONAL_ARGS --websocket-url=$RETH_FB_WEBSOCKET_URL"
     echo "Enabling Flashblocks support with endpoint: $RETH_FB_WEBSOCKET_URL"
 else
     echo "Running in vanilla node mode (no Flashblocks URL provided)"


### PR DESCRIPTION
Switch Flashblocks block to append --websocket-url instead of replacing the entire ADDITIONAL_ARGS value. This preserves any previously-defined flags and ensures pruning or custom arguments remain intact.