### PR TITLE
docs: add common node configuration combinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ Base is a secure, low-cost, developer-friendly Ethereum L2 built on Optimism's [
    NETWORK_ENV=.env.sepolia CLIENT=reth docker compose up --build
    ```
 
+   ### Common configuration combinations
+
+Use case | NETWORK_ENV | CLIENT | Command example
+--- | --- | --- | ---
+Mainnet, default | (default) | (default) | `docker compose up --build`
+Mainnet, geth | (default) | `geth` | `CLIENT=geth docker compose up --build`
+Mainnet, reth | (default) | `reth` | `CLIENT=reth docker compose up --build`
+Mainnet, nethermind | (default) | `nethermind` | `CLIENT=nethermind docker compose up --build`
+Sepolia, default | `.env.sepolia` | (default) | `NETWORK_ENV=.env.sepolia docker compose up --build`
+Sepolia, reth | `.env.sepolia` | `reth` | `NETWORK_ENV=.env.sepolia CLIENT=reth docker compose up --build`
+Sepolia, nethermind | `.env.sepolia` | `nethermind` | `NETWORK_ENV=.env.sepolia CLIENT=nethermind docker compose up --build`
+
 ### Supported Clients
 
 - `reth` (default)


### PR DESCRIPTION
Summary
- Add a quick table of common NETWORK_ENV and CLIENT combinations for Base node operators

Rationale
- Makes it easier for new operators to choose the right env file and client without guessing docker compose commands