### PR TITLE
docs: expand Quick Start env examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ Base is a secure, low-cost, developer-friendly Ethereum L2 built on Optimism's [
 
    # For testnet with a specific client:
    NETWORK_ENV=.env.sepolia CLIENT=reth docker compose up --build
+
+   # Use a specific client on mainnet:
+   CLIENT=reth docker compose up --build
+
+   # Combine testnet env with a specific client:
+   NETWORK_ENV=.env.sepolia CLIENT=geth docker compose up --build
+   
    ```
 
 ### Supported Clients


### PR DESCRIPTION
This PR extends the Quick Start section with a couple of concrete examples that combine NETWORK_ENV and CLIENT when starting the node.

It now shows:
- how to run mainnet with an explicit client;
- how to run Sepolia with a specific client in a single command.

Docs-only change, no impact on compose files or runtime configuration.
