### PR TITLE
chore: add pruning args to env file

### DIFF
--- a/.env.mainnet
+++ b/.env.mainnet
@@ -97,8 +97,8 @@ STATSD_ADDRESS="172.17.0.1"
 # FLASHBLOCKS (OPTIONAL - UNCOMMENT TO ENABLE)
 # RETH_FB_WEBSOCKET_URL=wss://mainnet.flashblocks.base.org/ws
 
-# PRUNING (OPTIONAL EXPERIMENTAL FEATURE - UNCOMMENT TO ENABLE)
-# NOTE: Pruning snapshots are not yet available
+# PRUNING (OPTIONAL - UNCOMMENT TO ENABLE)
 # NOTE: Set to any number of blocks you want, but it should be >10064
 # NOTE: The node type that was chosen when first running a node cannot be changed after the initial sync. Turning Archive into Pruned, or Pruned into Full is not supported [source](https://reth.rs/run/faq/pruning/).
+# NOTE: The pruned snapshots provided are set with a distance of 1_339_200 (~31 days).
 # RETH_PRUNING_ARGS="--prune.senderrecovery.distance=50000 --prune.transactionlookup.distance=50000 --prune.receipts.distance=50000 --prune.accounthistory.distance=50000 --prune.storagehistory.distance=50000 --prune.bodies.distance=50000"

--- a/.env.sepolia
+++ b/.env.sepolia
@@ -97,8 +97,8 @@ STATSD_ADDRESS="172.17.0.1"
 # FLASHBLOCKS (OPTIONAL - UNCOMMENT TO ENABLE)
 # RETH_FB_WEBSOCKET_URL=wss://sepolia.flashblocks.base.org/ws
 
-# PRUNING (OPTIONAL EXPERIMENTAL FEATURE - UNCOMMENT TO ENABLE)
-# NOTE: Pruning snapshots are not yet available
+# PRUNING (OPTIONAL - UNCOMMENT TO ENABLE)
 # NOTE: Set to any number of blocks you want, but it should be >10064
 # NOTE: The node type that was chosen when first running a node cannot be changed after the initial sync. Turning Archive into Pruned, or Pruned into Full is not supported [source](https://reth.rs/run/faq/pruning/).
+# NOTE: The pruned snapshots provided are set with a distance of 1_339_200 (~31 days).
 # RETH_PRUNING_ARGS="--prune.senderrecovery.distance=50000 --prune.transactionlookup.distance=50000 --prune.receipts.distance=50000 --prune.accounthistory.distance=50000 --prune.storagehistory.distance=50000 --prune.bodies.distance=50000"


### PR DESCRIPTION
Closes #658 

Adds optional `RETH_PRUNING_ARGS` flag to the `.env.sepolia` and `.env.mainnet` to make it clear how to run a Pruning mode node.