### PR TITLE
docs(troubleshooting): add rpc health hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Snapshots are available to help you sync your node more quickly. See [docs.base.
 ## Troubleshooting
 
 For support please join our [Discord](https://discord.gg/buildonbase) post in `🛠｜node-operators`. You can alternatively open a new GitHub issue.
+If your node is consistently lagging behind the chain head, verify that your L1 RPC and beacon endpoints are healthy, not rate limited, and correctly configured in the `OP_NODE_L1_*` and `OP_NODE_L1_RPC_KIND` settings above.
 
 ## Disclaimer
 


### PR DESCRIPTION
Summary
Document an additional troubleshooting note explaining that persistent lag can be caused by misconfigured or unhealthy L1 RPC and beacon endpoints.

Motivation
Operators often focus on node flags or hardware when diagnosing sync issues, while the real cause is an overloaded or rate‑limited L1 provider. Highlighting this in the README directs them to double‑check the `OP_NODE_L1_*` and `OP_NODE_L1_RPC_KIND` settings first.
