### PR TITLE
docs(snapshots): add restore safety note

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ For full configuration options, see the `.env.mainnet` file.
 ## Snapshots
 
 Snapshots are available to help you sync your node more quickly. See [docs.base.org](https://docs.base.org/chain/run-a-base-node#snapshots) for links and more details on how to restore from a snapshot.
+Before restoring from a snapshot, make sure all node services are stopped and back up any existing data directory you might want to keep.
 
 ## Supported Networks
 


### PR DESCRIPTION
### Summary

Add a short safety note to the snapshots section reminding operators to stop node services and back up existing data before restoring from a snapshot.

### Motivation

This reduces the risk of accidental data loss or corruption when operators use snapshots to speed up sync.
