### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,4 +30,4 @@ services:
       - "6060:6060" # pprof
     command: ["bash", "./op-node-entrypoint"]
     env_file:
-      - ${NETWORK_ENV:-.env.mainnet} # Use .env.mainnet by default, override with .env.sepolia for testnet
+      - ${NETWORK_ENV:-.env.mainnet} # Use .env.mainnet by default, override with .env.sepolia for testnet; NETWORK_ENV should point to a valid .env.* file


### PR DESCRIPTION
Summary

Clarify that NETWORK_ENV should point to a valid .env.* file when overriding the default .env.mainnet for the node service in docker-compose.yml.

Motivation

Helps node operators avoid misconfigurations when switching between mainnet and sepolia by making the expected value of NETWORK_ENV explicit in the compose file.
