### PR TITLE
docs(compose): explain host data dir

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "30303:30303/udp" # P2P UDP
     command: ["bash", "./execution-entrypoint"]
     volumes:
-      - ${HOST_DATA_DIR}:/data
+      - ${HOST_DATA_DIR}:/data # HOST_DATA_DIR controls where execution client data (chain state, logs) are stored on the host
     env_file:
       - ${NETWORK_ENV:-.env.mainnet} # Use .env.mainnet by default, override with .env.sepolia for testnet
   node:


### PR DESCRIPTION
Summary

Document that HOST_DATA_DIR controls where execution client data is stored on the host.

Motivation

Helps node operators understand which host path contains the chain state and logs, making backups and disk management safer.
