### PR TITLE
chore(docker-compose.yml): increased stop_grace_period

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
       context: .
       dockerfile: ${CLIENT:-geth}/Dockerfile
     restart: unless-stopped
+    stop_grace_period: 60s
     ports:
       - "8545:8545" # RPC
       - "8546:8546" # websocket
@@ -20,6 +21,7 @@ services:
       context: .
       dockerfile: ${CLIENT:-geth}/Dockerfile
     restart: unless-stopped
+    stop_grace_period: 30s
     depends_on:
       - execution
     ports:


### PR DESCRIPTION
Increased `stop_grace_period` in order to allow containers stop gracefully and avoid receiving SIGKILL from docker after 10s (default value).
Mostly relevant for execution, in my specific case stopping takes ~15s.
Potentially could help to get rid of op-node's `"msg":"Walking back L1Block by hash"` messages after updates/restarts.