### PR TITLE
fix: correct .env defaults and document HOST_DATA_DIR usage

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-CLIENT=${CLIENT:-geth}
-HOST_DATA_DIR=./${CLIENT}-data
+CLIENT=geth
+HOST_DATA_DIR=./geth-data

--- a/README.md
+++ b/README.md
@@ -32,10 +32,11 @@ Base is a secure, low-cost, developer-friendly Ethereum L2 built on Optimism's [
    NETWORK_ENV=.env.sepolia docker compose up --build
 
    # To use a specific client (optional):
-   CLIENT=reth docker compose up --build
+  # Note: if you change CLIENT, also set HOST_DATA_DIR so you don't mix client datadirs.
+  CLIENT=reth HOST_DATA_DIR=./reth-data docker compose up --build
 
    # For testnet with a specific client:
-   NETWORK_ENV=.env.sepolia CLIENT=reth docker compose up --build
+  NETWORK_ENV=.env.sepolia CLIENT=reth HOST_DATA_DIR=./reth-data docker compose up --build
    ```
 
 ### Supported Clients


### PR DESCRIPTION
## Summary

This PR fixes an issue with the default `.env` file and improves documentation to prevent users from accidentally mixing client data directories.

## Problem

The original `.env` file used shell variable interpolation syntax (`${CLIENT:-geth}`) which is **not supported** by Docker Compose's env_file parsing. Docker Compose reads `.env` files as simple `KEY=VALUE` pairs without shell expansion, meaning:

- `HOST_DATA_DIR` would resolve to the literal string `./${CLIENT}-data` instead of `./geth-data`
- This could cause confusing volume mount issues

Additionally, when users switch clients (e.g., from `geth` to `reth`), they need to also update `HOST_DATA_DIR` to avoid mixing data from different clients in the same directory.

## Changes

### `.env`
- Replace unsupported variable interpolation with static defaults (`CLIENT=geth`, `HOST_DATA_DIR=./geth-data`)
- Add trailing newline for POSIX compliance

### `README.md`
- Add note explaining that `HOST_DATA_DIR` should be set when changing `CLIENT`
- Update example commands to show the correct usage pattern

## Testing

- Verified `.env` now ends with a proper newline
- Changes are documentation/config only - no functional code changes