### PR TITLE
Fix typo and improve clarity for Base node docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Supported clients:
  - geth
  - nethermind
 
-## Configuration
+###Configuration
 
 ### Required Settings
 


### PR DESCRIPTION
Corrected minor typo and clarified instructions in Base node repository.