### PR TITLE
docs: add Default Ports and Stopping the Node sections to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,44 @@ Base is a secure, low-cost, developer-friendly Ethereum L2 built on Optimism's [
 - `geth`
 - `nethermind`
 
+## Default Ports
+
+The node exposes the following ports by default:
+
+**Execution Client:**
+| Port | Protocol | Description |
+|------|----------|-------------|
+| 8545 | TCP | HTTP JSON-RPC |
+| 8546 | TCP | WebSocket |
+| 7301 | TCP | Metrics |
+| 30303 | TCP/UDP | P2P |
+
+**OP Node:**
+| Port | Protocol | Description |
+|------|----------|-------------|
+| 7545 | TCP | HTTP JSON-RPC |
+| 9222 | TCP/UDP | P2P |
+| 7300 | TCP | Metrics |
+| 6060 | TCP | pprof |
+
+These ports can be customized by modifying the `docker-compose.yml` file.
+
+## Stopping the Node
+
+To stop the node gracefully:
+
+```bash
+docker compose down
+```
+
+To stop the node and remove all data volumes (full reset):
+
+```bash
+docker compose down -v
+```
+
+If running in the foreground, you can also press `Ctrl+C` to initiate a graceful shutdown.
+
 ## Requirements
 
 ### Minimum Requirements


### PR DESCRIPTION
## Summary

This PR adds two new documentation sections to the README to help new users:

1. **Default Ports** - Documents all exposed ports for the Execution Client and OP Node
2. **Stopping the Node** - Explains how to gracefully shut down the node

## Changes

- Added "Default Ports" section with tables documenting:
  - Execution Client ports (8545, 8546, 7301, 30303)
  - OP Node ports (7545, 9222, 7300, 6060)
- Added "Stopping the Node" section with:
  - `docker compose down` for graceful shutdown
  - `docker compose down -v` for full reset
  - Note about `Ctrl+C` for foreground shutdown

## Issues

Closes #903
Closes #904

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author