### PR TITLE
chore(security): comment out public P2P ports 30303 in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,11 @@ services:
       dockerfile: ${CLIENT:-geth}/Dockerfile
     restart: unless-stopped
     ports:
-      - "8545:8545" # RPC
-      - "8546:8546" # websocket
-      - "7301:6060" # metrics
-      - "30303:30303" # P2P TCP
-      - "30303:30303/udp" # P2P UDP
+      - "8545:8545"   # RPC
+      - "8546:8546"   # websocket
+      - "7301:6060"   # metrics
+      # - "30303:30303"     # P2P TCP   (commented out for security: avoid public exposure by default)
+      # - "30303:30303/udp" # P2P UDP   (commented out for security: avoid public exposure by default)
     command: ["bash", "./execution-entrypoint"]
     volumes:
       - ${HOST_DATA_DIR}:/data


### PR DESCRIPTION
**What this PR does / Why we need it:**

By default, the `docker-compose.yml` exposes the P2P ports (30303 TCP and UDP) publicly for the execution client service. This unnecessarily increases the attack surface for node operators, potentially exposing nodes to DDoS attacks, port scanning, or other P2P-related vulnerabilities.

Most node operators do not require these ports to be publicly accessible (they can use private peering, VPN, or firewall rules). Commenting them out by default enhances security while preserving flexibility—users who need public P2P can simply uncomment the lines.

**Changes:**
- Commented out the following lines in the `execution` service:
  ```yaml
  # - "30303:30303"     # P2P TCP   (commented out for security: avoid public exposure by default)
  # - "30303:30303/udp" # P2P UDP   (commented out for security: avoid public exposure by default)
  
<img width="1474" height="184" alt="docker-compose-ps-up" src="https://github.com/user-attachments/assets/1f5f66df-3a4a-4167-88da-9c6a9bf9b091" />
<img width="1073" height="211" alt="ss-ports-no-30303" src="https://github.com/user-attachments/assets/5e4ec1fe-ae90-4ac4-947f-e2e4421259d2" />
Verification (tested locally on WSL2 + Docker Desktop):
docker compose config → YAML valid, no syntax errors.
docker compose up -d --build → Images built successfully; services execution and node started and running (Up status).
docker compose ps -a → Containers up and healthy.
Listening ports checked with ss -tuln: Confirmed ports 8545, 9222, 7300, 6060 etc. exposed as expected; no listening on 30303 TCP/UDP on the host (P2P ports successfully not exposed publicly).
Screenshots / Proof of testing:
Container status (docker compose ps -a):
[trascina qui il file docker-compose-ps-up.png oppure clicca l'icona di allegato e caricalo]
Listening ports on host (ss -tuln – 30303 absent):
[trascina qui il file ss-ports-no-30303.png oppure allega]
References / Best practices:
Docker Compose docs: Expose only necessary ports
Common OP Stack / Ethereum node security advice: avoid default public P2P exposure.
Happy to make adjustments (e.g. remove lines instead of commenting). Thanks for reviewing!