### PR TITLE
chore(logging): enable rotated logging for supervisord to improve debugging

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,18 +1,20 @@
 [supervisord]
 nodaemon=true
-logfile=/dev/null
-logfile_maxbytes=0
+logfile=/var/log/supervisord/supervisord.log      ; file principale per log di supervisord
+logfile_maxbytes=50MB                             ; ruota quando supera 50MB
+logfile_backups=10                                ; tieni 10 backup (supervisord.log.1 ... .10)
+loglevel=info                                     ; livello: info (normale), riduce rumore ma utile
 
 [program:op-node]
 command=/app/op-node-entrypoint
-stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
+stdout_logfile=/dev/fd/1                          ; mantieni stdout su container (docker logs)
+stdout_logfile_maxbytes=0                         ; no rotation su stdout (Docker gestisce)
 redirect_stderr=true
 stopwaitsecs=300
 
 [program:op-execution]
 command=/app/execution-entrypoint
-stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
+stdout_logfile=/dev/fd/1                          ; mantieni stdout su container
+stdout_logfile_maxbytes=0                         ; no rotation su stdout
 redirect_stderr=true
 stopwaitsecs=300


### PR DESCRIPTION
**What this PR does / Why we need it:**

Currently, supervisord activity logs are discarded to `/dev/null`, making it impossible to debug supervisord itself (e.g., process restarts, config issues, errors).

This PR enables proper rotated logging for the supervisord activity log:
- logfile=/var/log/supervisord/supervisord.log
- Rotation at 50MB with 10 backups
- loglevel=info for useful but not excessive output

Program stdout/stderr remain redirected to container stdout (visible via `docker compose logs`), no changes there.

**Changes:**
- Updated [supervisord] section to enable logfile and rotation.
- No breaking changes to program sections.

**Verification (tested locally on WSL2 + Docker Desktop):**
- `docker compose up -d --build` → Services start successfully.
- `docker compose logs` → No loss of program output; supervisord events now loggable (if issues occur).
- Config remains minimal and production-safe.

**References:**
- Supervisord logging docs: http://supervisord.org/logging.html (recommends logfile_maxbytes and backups for rotation)

Open to adjustments (e.g., different path, size, or per-program logs). Thanks for reviewing!