### PR TITLE
enhance(docker): add healthcheck to execution + conditional depends_on for node

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,13 +15,21 @@ services:
       - ${HOST_DATA_DIR}:/data
     env_file:
       - ${NETWORK_ENV:-.env.mainnet} # Use .env.mainnet by default, override with .env.sepolia for testnet
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:6060"]  # Controlla l'endpoint metrics interno (6060)
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s                                     # dà tempo all'execution client di avviarsi
+
   node:
     build:
       context: .
       dockerfile: ${CLIENT:-geth}/Dockerfile
     restart: unless-stopped
     depends_on:
-      - execution
+      execution:
+        condition: service_healthy                          # node parte SOLO quando execution è healthy
     ports:
       - "7545:8545" # RPC
       - "9222:9222" # P2P TCP


### PR DESCRIPTION
**What this PR does / Why we need it:**

Currently, `depends_on: [execution]` only waits for the container to start, not for the execution client (Geth/Reth) to be fully ready (e.g., RPC responding). This often causes op-node to crash or loop on startup with "execution RPC not ready" errors.

This PR fixes it with Docker Compose best practices:
- Adds a simple healthcheck to `execution` service (curl on internal metrics endpoint 6060).
- Changes `depends_on` in `node` to `condition: service_healthy`.

**Changes:**
- Added healthcheck block to `execution`:
  ```yaml
  healthcheck:
    test: ["CMD", "curl", "-f", "http://localhost:6060"]
    interval: 30s
    timeout: 10s
    retries: 5
    start_period: 60s
    
    Updated node depends_on:YAML
    depends_on:
  execution:
    condition: service_healthy
    
    Verification (tested locally on WSL2 + Docker Desktop):

docker compose config → Valid YAML.
docker compose up -d --build → Services start; execution becomes "healthy" after init.
docker compose ps: execution shows health status; node waits properly.
No crashes from premature op-node startup.

References:

Docker Compose docs: https://docs.docker.com/compose/compose-file/05-services/#healthcheck
https://docs.docker.com/compose/compose-file/05-services/#dependson (condition: service_healthy)

Open to tweaks (e.g., different test endpoint like 8545 RPC, adjust timings). Thanks for reviewing!