### PR TITLE
docs: add clean stop instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ Base is a secure, low-cost, developer-friendly Ethereum L2 built on Optimism's [
    # For testnet with a specific client:
    NETWORK_ENV=.env.sepolia CLIENT=reth docker compose up --build
    ```
+5. Stop the node cleanly:
+
+   ```bash
+   # If running in the foreground, press Ctrl+C to stop containers.
+   # To stop and remove containers:
+   docker compose down
+   ```
 
 ### Supported Clients
 


### PR DESCRIPTION
Adds a Quick Start step explaining how to stop the node cleanly (Ctrl+C for foreground, docker compose down to stop/remove containers).
Addresses: “Mention how to stop the node cleanly in the README” (#904)