### PR TITLE
chore: update base reth to v0.4.0

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -1,6 +1,6 @@
-export BASE_RETH_NODE_COMMIT=fa6d3444debd96977ae14ccae502b91cbbe3f463
+export BASE_RETH_NODE_COMMIT=00087fd960f65a79b6ce87e55e3b3440c99237fa
 export BASE_RETH_NODE_REPO=https://github.com/base/base.git
-export BASE_RETH_NODE_TAG=v0.3.1
+export BASE_RETH_NODE_TAG=v0.4.0
 export NETHERMIND_COMMIT=31cb81b7328026791cdfaccd9db230c82f1db02d
 export NETHERMIND_REPO=https://github.com/NethermindEth/nethermind.git
 export NETHERMIND_TAG=1.36.0

--- a/versions.json
+++ b/versions.json
@@ -1,7 +1,7 @@
 {
 	  "base_reth_node": {
-	  	  "tag": "v0.3.1",
-	  	  "commit": "fa6d3444debd96977ae14ccae502b91cbbe3f463",
+	  	  "tag": "v0.4.0",
+	  	  "commit": "00087fd960f65a79b6ce87e55e3b3440c99237fa",
 	  	  "owner": "base",
 	  	  "repo": "base",
 	  	  "tracking": "release"


### PR DESCRIPTION
### Description
* [base/base 0.4.0](https://github.com/base/base/releases/tag/v0.4.0) [diff](https://github.com/base/base/compare/v0.3.1...v0.4.0)