### PR TITLE
feat: add healthcheck to execution service and wait condition for consensus

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,13 +17,20 @@ services:
       - USE_BASE_CONSENSUS=${USE_BASE_CONSENSUS:-false}
     env_file:
       - ${NETWORK_ENV:-.env.mainnet} # Use .env.mainnet by default, override with .env.sepolia for testnet
+    healthcheck:
+      test: ["CMD", "sh", "-c", "curl -sf -X POST -H 'Content-Type: application/json' --data '{\"jsonrpc\":\"2.0\",\"method\":\"eth_syncing\",\"params\":[],\"id\":1}' http://localhost:8545"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
   node:
     build:
       context: .
       dockerfile: ${CLIENT:-geth}/Dockerfile
     restart: unless-stopped
     depends_on:
-      - execution
+      execution:
+        condition: service_healthy
     ports:
       - "7545:8545" # RPC
       - "9222:9222" # P2P TCP


### PR DESCRIPTION
## Problem

When running `docker compose up`, the `node` service (consensus client) starts immediately after the `execution` container is created — not after it's actually ready to serve requests. On first boot or after a restart with a large database, the execution client can take 30–120 seconds before its JSON-RPC becomes available. During this window the consensus service repeatedly fails to connect and enters a crash-loop.

This is a frequently reported issue in the `#🛠｜node-operators` Discord channel.

## Solution

- Add a `healthcheck` to the `execution` service that polls `eth_syncing` via JSON-RPC. The check passes as soon as the RPC endpoint responds (the node does not need to be fully synced — just started).
- Change `depends_on` on the `node` service to `condition: service_healthy` so the consensus client only starts once the execution client's RPC is live.

## Healthcheck parameters

| Parameter | Value | Reason |
|---|---|---|
| `interval` | 30s | Re-poll every 30 seconds |
| `timeout` | 10s | Single-request timeout |
| `retries` | 5 | Mark unhealthy after 5 consecutive failures |
| `start_period` | 60s | Grace window for slow DB init on first boot |

## Testing

Verified with `CLIENT=reth` and `CLIENT=geth`. The `node` service now waits correctly on fresh starts and after `docker compose restart execution`.

## Backwards compatibility

No changes to `.env` files or entrypoints. Existing deployments require no migration.