### PR TITLE
fix: standardise LOG_LEVEL across all execution-client entrypoints

### DIFF
--- a/geth/geth-entrypoint
+++ b/geth/geth-entrypoint
@@ -1,7 +1,23 @@
 #!/bin/bash
 set -eu
 
-VERBOSITY=${GETH_VERBOSITY:-3}
+# GETH_VERBOSITY sets the numeric log level (0=crit, 1=error, 2=warn, 3=info, 4=debug, 5=trace)
+# LOG_LEVEL accepts human-readable aliases and takes precedence when set
+if [[ -n "${LOG_LEVEL:-}" ]]; then
+    case "$LOG_LEVEL" in
+        "error") VERBOSITY=1 ;;
+        "warn")  VERBOSITY=2 ;;
+        "info")  VERBOSITY=3 ;;
+        "debug") VERBOSITY=4 ;;
+        "trace") VERBOSITY=5 ;;
+        *)
+            echo "Invalid LOG_LEVEL: $LOG_LEVEL. Valid values: error, warn, info, debug, trace" 1>&2
+            exit 1
+            ;;
+    esac
+else
+    VERBOSITY=${GETH_VERBOSITY:-3}
+fi
 GETH_DATA_DIR=${GETH_DATA_DIR:-/data}
 RPC_PORT="${RPC_PORT:-8545}"
 WS_PORT="${WS_PORT:-8546}"

--- a/nethermind/nethermind-entrypoint
+++ b/nethermind/nethermind-entrypoint
@@ -3,7 +3,23 @@ set -eu
 
 # Default configurations
 NETHERMIND_DATA_DIR=${NETHERMIND_DATA_DIR:-/data}
-NETHERMIND_LOG_LEVEL=${NETHERMIND_LOG_LEVEL:-Info}
+# NETHERMIND_LOG_LEVEL accepts Nethermind log levels: Trace, Debug, Info, Warn, Error
+# LOG_LEVEL accepts human-readable aliases and takes precedence when set
+if [[ -n "${LOG_LEVEL:-}" ]]; then
+    case "$LOG_LEVEL" in
+        "error") NETHERMIND_LOG_LEVEL="Error" ;;
+        "warn")  NETHERMIND_LOG_LEVEL="Warn" ;;
+        "info")  NETHERMIND_LOG_LEVEL="Info" ;;
+        "debug") NETHERMIND_LOG_LEVEL="Debug" ;;
+        "trace") NETHERMIND_LOG_LEVEL="Trace" ;;
+        *)
+            echo "Invalid LOG_LEVEL: $LOG_LEVEL. Valid values: error, warn, info, debug, trace" 1>&2
+            exit 1
+            ;;
+    esac
+else
+    NETHERMIND_LOG_LEVEL=${NETHERMIND_LOG_LEVEL:-Info}
+fi
 
 RPC_PORT="${RPC_PORT:-8545}"
 WS_PORT="${WS_PORT:-8546}"

--- a/reth/reth-entrypoint
+++ b/reth/reth-entrypoint
@@ -45,8 +45,8 @@ case "$LOG_LEVEL" in
         LOG_LEVEL="vvvvv"
         ;;
     *)
-        echo "Unknown log level: $LOG_LEVEL"
-        LOG_LEVEL="vvv"
+        echo "Invalid LOG_LEVEL: $LOG_LEVEL. Valid values: error, warn, info, debug, trace" 1>&2
+        exit 1
         ;;
 esac
 


### PR DESCRIPTION
## Problem

All three execution-client entrypoints (`reth`, `geth`, `nethermind`) handle log verbosity differently, making it impossible to set a consistent log level across client types with a single environment variable.

Specific issues:

1. **reth-entrypoint**: an unrecognised `LOG_LEVEL` value silently fell through to the default (`info`) with only an `echo` warning — no stderr, no exit code. Operators mistyping `INFO` or `WARNING` got no feedback.

2. **geth-entrypoint**: only `GETH_VERBOSITY` (numeric, `0`–`5`) was supported. There was no human-readable alternative.

3. **nethermind-entrypoint**: only Nethermind-specific capitalised level names (`Info`, `Debug`, etc.) were accepted via `NETHERMIND_LOG_LEVEL`. No shared interface with the other clients.

Meanwhile the consensus side already supports `OP_NODE_LOG_LEVEL=info` — there was no equivalent for execution clients.

## Solution

- **reth**: change the wildcard `case` arm to print an error to stderr and `exit 1`
- **geth**: add a `LOG_LEVEL` pre-processing block that maps `error/warn/info/debug/trace` → numeric verbosity; falls back to `GETH_VERBOSITY` when `LOG_LEVEL` is unset
- **nethermind**: same approach, mapping to Nethermind's `Error/Warn/Info/Debug/Trace` strings; falls back to `NETHERMIND_LOG_LEVEL`

## Result

Operators can now set `LOG_LEVEL=debug` once in their `.env` file and have it apply uniformly across all three execution clients.

## Backwards compatibility

All existing `GETH_VERBOSITY` and `NETHERMIND_LOG_LEVEL` variables continue to work unchanged. `LOG_LEVEL` only takes effect when explicitly set.