### PR TITLE
docs: document HOST_IP in env files for better peer discovery

### DIFF
--- a/.env.mainnet
+++ b/.env.mainnet
@@ -46,6 +46,12 @@ BASE_NODE_L2_ENGINE_AUTH_RAW=688f5d737bad920bdfb2fc2f488d6b6209eebda1dae949a8de9
 
 # P2P CONFIGURATION
 # ---------------
+# HOST_IP (optional): Set this to your public-facing IPv4 address to improve peer discovery.
+# When set, the execution client advertises this address instead of the Docker internal IP.
+# Recommended for nodes behind NAT or in cloud environments (AWS, GCP, Hetzner, etc.).
+# Leave empty for automatic detection (works for most home/VPS setups).
+# Example: HOST_IP=1.2.3.4
+HOST_IP=
 OP_NODE_P2P_AGENT=base
 OP_NODE_P2P_LISTEN_IP=0.0.0.0
 OP_NODE_P2P_LISTEN_TCP_PORT=9222

--- a/.env.sepolia
+++ b/.env.sepolia
@@ -46,6 +46,12 @@ BASE_NODE_L2_ENGINE_AUTH_RAW=688f5d737bad920bdfb2fc2f488d6b6209eebda1dae949a8de9
 
 # P2P CONFIGURATION
 # ---------------
+# HOST_IP (optional): Set this to your public-facing IPv4 address to improve peer discovery.
+# When set, the execution client advertises this address instead of the Docker internal IP.
+# Recommended for nodes behind NAT or in cloud environments (AWS, GCP, Hetzner, etc.).
+# Leave empty for automatic detection (works for most home/VPS setups).
+# Example: HOST_IP=1.2.3.4
+HOST_IP=
 OP_NODE_P2P_AGENT=base
 OP_NODE_P2P_LISTEN_IP=0.0.0.0
 OP_NODE_P2P_LISTEN_TCP_PORT=9222


### PR DESCRIPTION
## Problem

The `geth-entrypoint` script has supported a `HOST_IP` variable since early on — when set, it passes `--nat=extip:$HOST_IP` to geth so the node advertises its real public address instead of the Docker internal IP. However `HOST_IP` was never documented in either `.env.mainnet` or `.env.sepolia`.

Operators running behind NAT or in cloud environments (AWS, GCP, Hetzner, etc.) have no way of discovering this option from the config files. The result is poor peer counts and degraded sync performance for a large portion of node operators.

## Solution

Add `HOST_IP=` to the `P2P CONFIGURATION` section of both `.env.mainnet` and `.env.sepolia` with a clear comment explaining:
- What the variable does
- When to set it (NAT / cloud / container networking)
- That leaving it empty triggers automatic detection (fine for most setups)
- A concrete example value

## Changes

- `.env.mainnet` — added `HOST_IP=` with documentation
- `.env.sepolia` — same

## Backwards compatibility

No code changes. Existing deployments are completely unaffected.