### PR TITLE
fix: update default client from geth to reth in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   execution:
     build:
       context: .
-      dockerfile: ${CLIENT:-geth}/Dockerfile
+      dockerfile: ${CLIENT:-reth}/Dockerfile
     restart: unless-stopped
     ports:
       - "8545:8545" # RPC
@@ -20,7 +20,7 @@ services:
   node:
     build:
       context: .
-      dockerfile: ${CLIENT:-geth}/Dockerfile
+      dockerfile: ${CLIENT:-reth}/Dockerfile
     restart: unless-stopped
     depends_on:
       - execution


### PR DESCRIPTION
Fixes #1010

README lists reth as the default client, but docker-compose.yml was defaulting to geth. Updated docker-compose.yml to match the documented default.