### PR TITLE
fix(reth): replace deprecated docker-compose with docker compose

### DIFF
--- a/reth/README.md
+++ b/reth/README.md
@@ -17,11 +17,11 @@ The node determines its mode based on the presence of the `RETH_FB_WEBSOCKET_URL
 
 ## Running the Node
 
-The node follows the standard `docker-compose` workflow in the master README.
+The node follows the standard `docker compose` workflow in the master README.
 
 ```bash
 # To run Reth node with Flashblocks support, set RETH_FB_WEBSOCKET_URL in your .env file
-CLIENT=reth docker-compose up
+CLIENT=reth docker compose up
 ```
 
 ## Testing Flashblocks RPC Methods


### PR DESCRIPTION
Fixes #1012

Replaced legacy `docker-compose` (hyphenated) with the modern `docker compose` plugin syntax in reth/README.md. Main README already uses the correct format.