### PR TITLE
fix: add USE_BASE_CONSENSUS=true to .env.mainnet and .env.sepolia

### DIFF
--- a/.env.mainnet
+++ b/.env.mainnet
@@ -120,3 +120,6 @@ STATSD_ADDRESS="172.17.0.1"
 # NOTE: The node type that was chosen when first running a node cannot be changed after the initial sync. Turning Archive into Pruned, or Pruned into Full is not supported [source](https://reth.rs/run/faq/pruning/).
 # NOTE: The pruned snapshots provided are set with a distance of 1_339_200 (~31 days).
 # RETH_PRUNING_ARGS="--prune.senderrecovery.distance=50000 --prune.transactionlookup.distance=50000 --prune.receipts.distance=50000 --prune.accounthistory.distance=50000 --prune.storagehistory.distance=50000 --prune.bodies.distance=50000"
+
+# BASE CONSENSUS CONFIGURATION
+USE_BASE_CONSENSUS=true

--- a/.env.sepolia
+++ b/.env.sepolia
@@ -120,3 +120,6 @@ STATSD_ADDRESS="172.17.0.1"
 # NOTE: The node type that was chosen when first running a node cannot be changed after the initial sync. Turning Archive into Pruned, or Pruned into Full is not supported [source](https://reth.rs/run/faq/pruning/).
 # NOTE: The pruned snapshots provided are set with a distance of 1_339_200 (~31 days).
 # RETH_PRUNING_ARGS="--prune.senderrecovery.distance=50000 --prune.transactionlookup.distance=50000 --prune.receipts.distance=50000 --prune.accounthistory.distance=50000 --prune.storagehistory.distance=50000 --prune.bodies.distance=50000"
+
+# BASE CONSENSUS CONFIGURATION
+USE_BASE_CONSENSUS=true


### PR DESCRIPTION
Fixes #1014

The .env file sets USE_BASE_CONSENSUS=true, but .env.mainnet and .env.sepolia were missing this variable entirely.

Since docker-compose.yml defaults to false, operators using NETWORK_ENV=.env.sepolia or .env.mainnet would silently fall back to op-node instead of base-consensus — missing the Base V1 upgrade on April 20th.

This adds USE_BASE_CONSENSUS=true to both env files to ensure base-consensus is used by default.