### PR TITLE
fix: add base-consensus binary to geth and nethermind Dockerfiles

### DIFF
--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -25,6 +25,38 @@ RUN . /tmp/versions.env && git clone $OP_GETH_REPO --branch $OP_GETH_TAG --singl
 
 RUN go run build/ci.go install -static ./cmd/geth
 
+
+ARG RUST_VERSION=1.93
+FROM public.ecr.aws/docker/library/rust:${RUST_VERSION}-trixie AS rust-builder-base
+WORKDIR /app
+ARG MOLD_VERSION=2.40.4
+ARG MOLD_SHA256_AARCH64=c799b9ccae8728793da2186718fbe53b76400a9da396184fac0c64aa3298ec37
+ARG MOLD_SHA256_ARM=d82792748a81202423ddd2496fc8719404fe694493abdef691cc080392ee44bf
+ARG MOLD_SHA256_X86_64=4c999e19ffa31afa5aa429c679b665d5e2ca5a6b6832ad4b79668e8dcf3d8ec1
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      git libclang-dev pkg-config curl build-essential cmake && \
+    rm -rf /var/lib/apt/lists/*
+RUN set -eux; \
+    case "$(uname -m)" in \
+      x86_64) MOLD_ARCH=x86_64; MOLD_SHA256="${MOLD_SHA256_X86_64}" ;; \
+      aarch64|arm64) MOLD_ARCH=aarch64; MOLD_SHA256="${MOLD_SHA256_AARCH64}" ;; \
+      armv7l|armv6l) MOLD_ARCH=arm; MOLD_SHA256="${MOLD_SHA256_ARM}" ;; \
+      *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux.tar.gz" -o /tmp/mold.tar.gz; \
+    echo "${MOLD_SHA256}  /tmp/mold.tar.gz" | sha256sum -c -; \
+    tar -xzf /tmp/mold.tar.gz -C /tmp; \
+    cp /tmp/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux/bin/* /usr/local/bin/; \
+    rm -rf /tmp/mold*
+
+FROM rust-builder-base AS base-consensus-builder
+WORKDIR /app
+COPY versions.env /tmp/versions.env
+RUN . /tmp/versions.env && git clone $BASE_RETH_NODE_REPO . && \
+    git checkout tags/$BASE_RETH_NODE_TAG && \
+    bash -c '[ "$(git rev-parse HEAD)" = "$BASE_RETH_NODE_COMMIT" ]' || (echo "Commit hash verification failed" && exit 1)
+RUN cargo build --bin base-consensus --profile maxperf
 FROM ubuntu:24.04
 
 RUN apt-get update && \
@@ -36,9 +68,11 @@ WORKDIR /app
 
 COPY --from=op /app/op-node/bin/op-node ./
 COPY --from=geth /app/build/bin/geth ./
+COPY --from=base-consensus-builder /app/target/maxperf/base-consensus ./
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY geth/geth-entrypoint ./execution-entrypoint
 COPY op-node-entrypoint .
+COPY base-consensus-entrypoint .
 COPY consensus-entrypoint .
 
 CMD ["/usr/bin/supervisord"]

--- a/nethermind/Dockerfile
+++ b/nethermind/Dockerfile
@@ -13,6 +13,38 @@ RUN . /tmp/versions.env && git clone $OP_NODE_REPO --branch $OP_NODE_TAG --singl
 RUN . /tmp/versions.env && cd op-node && \
     just VERSION=$OP_NODE_TAG op-node
 
+
+ARG RUST_VERSION=1.93
+FROM public.ecr.aws/docker/library/rust:${RUST_VERSION}-trixie AS rust-builder-base
+WORKDIR /app
+ARG MOLD_VERSION=2.40.4
+ARG MOLD_SHA256_AARCH64=c799b9ccae8728793da2186718fbe53b76400a9da396184fac0c64aa3298ec37
+ARG MOLD_SHA256_ARM=d82792748a81202423ddd2496fc8719404fe694493abdef691cc080392ee44bf
+ARG MOLD_SHA256_X86_64=4c999e19ffa31afa5aa429c679b665d5e2ca5a6b6832ad4b79668e8dcf3d8ec1
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      git libclang-dev pkg-config curl build-essential cmake && \
+    rm -rf /var/lib/apt/lists/*
+RUN set -eux; \
+    case "$(uname -m)" in \
+      x86_64) MOLD_ARCH=x86_64; MOLD_SHA256="${MOLD_SHA256_X86_64}" ;; \
+      aarch64|arm64) MOLD_ARCH=aarch64; MOLD_SHA256="${MOLD_SHA256_AARCH64}" ;; \
+      armv7l|armv6l) MOLD_ARCH=arm; MOLD_SHA256="${MOLD_SHA256_ARM}" ;; \
+      *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux.tar.gz" -o /tmp/mold.tar.gz; \
+    echo "${MOLD_SHA256}  /tmp/mold.tar.gz" | sha256sum -c -; \
+    tar -xzf /tmp/mold.tar.gz -C /tmp; \
+    cp /tmp/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux/bin/* /usr/local/bin/; \
+    rm -rf /tmp/mold*
+
+FROM rust-builder-base AS base-consensus-builder
+WORKDIR /app
+COPY versions.env /tmp/versions.env
+RUN . /tmp/versions.env && git clone $BASE_RETH_NODE_REPO . && \
+    git checkout tags/$BASE_RETH_NODE_TAG && \
+    bash -c '[ "$(git rev-parse HEAD)" = "$BASE_RETH_NODE_COMMIT" ]' || (echo "Commit hash verification failed" && exit 1)
+RUN cargo build --bin base-consensus --profile maxperf
 FROM mcr.microsoft.com/dotnet/sdk:10.0-noble AS build
 
 ARG BUILD_CONFIG=release
@@ -43,9 +75,11 @@ WORKDIR /app
 
 COPY --from=build /publish ./
 COPY --from=op /app/op-node/bin/op-node ./
+COPY --from=base-consensus-builder /app/target/maxperf/base-consensus ./
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY nethermind/nethermind-entrypoint ./execution-entrypoint
 COPY op-node-entrypoint .
+COPY base-consensus-entrypoint .
 COPY consensus-entrypoint .
 
 CMD ["/usr/bin/supervisord"]


### PR DESCRIPTION
Fixes #1016

reth/Dockerfile already includes the base-consensus binary, but geth/Dockerfile and nethermind/Dockerfile were missing it entirely.

Operators using geth or nethermind with USE_BASE_CONSENSUS=true would get "Base client is not supported for this node type" error and fail to start — potentially missing the April 20th Base V1 Sepolia upgrade deadline.

Changes:
- Added Rust builder stage to both Dockerfiles
- Added base-consensus binary copy from builder
- Added base-consensus-entrypoint copy