### PR TITLE
fix: add USE_BASE_CONSENSUS to .env.mainnet and .env.sepolia

### DIFF
--- a/.env.mainnet
+++ b/.env.mainnet
@@ -120,3 +120,5 @@ STATSD_ADDRESS="172.17.0.1"
 # NOTE: The node type that was chosen when first running a node cannot be changed after the initial sync. Turning Archive into Pruned, or Pruned into Full is not supported [source](https://reth.rs/run/faq/pruning/).
 # NOTE: The pruned snapshots provided are set with a distance of 1_339_200 (~31 days).
 # RETH_PRUNING_ARGS="--prune.senderrecovery.distance=50000 --prune.transactionlookup.distance=50000 --prune.receipts.distance=50000 --prune.accounthistory.distance=50000 --prune.storagehistory.distance=50000 --prune.bodies.distance=50000"
+
+USE_BASE_CONSENSUS=true

--- a/.env.sepolia
+++ b/.env.sepolia
@@ -120,3 +120,5 @@ STATSD_ADDRESS="172.17.0.1"
 # NOTE: The node type that was chosen when first running a node cannot be changed after the initial sync. Turning Archive into Pruned, or Pruned into Full is not supported [source](https://reth.rs/run/faq/pruning/).
 # NOTE: The pruned snapshots provided are set with a distance of 1_339_200 (~31 days).
 # RETH_PRUNING_ARGS="--prune.senderrecovery.distance=50000 --prune.transactionlookup.distance=50000 --prune.receipts.distance=50000 --prune.accounthistory.distance=50000 --prune.storagehistory.distance=50000 --prune.bodies.distance=50000"
+
+USE_BASE_CONSENSUS=true


### PR DESCRIPTION
The .env file sets `USE_BASE_CONSENSUS=true`, but `.env.mainnet` and `.env.sepolia` did not include this variable. Since `docker-compose.yml` defaults to false when the variable is unset:

```yaml
USE_BASE_CONSENSUS=${USE_BASE_CONSENSUS:-false}
```

Operators running with `NETWORK_ENV=.env.mainnet` or `NETWORK_ENV=.env.sepolia` would silently use op-node instead of base-consensus, and would fail to support the Base V1 upgrade.

Fixes #1014.