### PR TITLE
feat: Bump base/base to 0.7.5

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -1,6 +1,6 @@
-export BASE_RETH_NODE_COMMIT=48b739f377349ff15c659b1405be3f5a1933a505
+export BASE_RETH_NODE_COMMIT=497254884e5309994ee5bd1ba106efb36aaacd75
 export BASE_RETH_NODE_REPO=https://github.com/base/base.git
-export BASE_RETH_NODE_TAG=v0.7.4
+export BASE_RETH_NODE_TAG=v0.7.5
 export NETHERMIND_COMMIT=f5507dec1c9c7f5e31dadae445c08622be166054
 export NETHERMIND_REPO=https://github.com/NethermindEth/nethermind.git
 export NETHERMIND_TAG=1.36.2

--- a/versions.json
+++ b/versions.json
@@ -1,7 +1,7 @@
 {
 	  "base_reth_node": {
-	  	  "tag": "v0.7.4",
-	  	  "commit": "48b739f377349ff15c659b1405be3f5a1933a505",
+	  	  "tag": "v0.7.5",
+	  	  "commit": "497254884e5309994ee5bd1ba106efb36aaacd75",
 	  	  "owner": "base",
 	  	  "repo": "base",
 	  	  "tracking": "release"


### PR DESCRIPTION
## Summary

Bumps `base/base` to `0.7.5` which includes a fix to `base-consensus` for l1 confs.