### PR TITLE
bump: base/base to 0.7.6

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -1,6 +1,6 @@
-export BASE_RETH_NODE_COMMIT=497254884e5309994ee5bd1ba106efb36aaacd75
+export BASE_RETH_NODE_COMMIT=5759d44b9384fd2ecde6c3fea6372e7c096e6267
 export BASE_RETH_NODE_REPO=https://github.com/base/base.git
-export BASE_RETH_NODE_TAG=v0.7.5
+export BASE_RETH_NODE_TAG=v0.7.6
 export NETHERMIND_COMMIT=f5507dec1c9c7f5e31dadae445c08622be166054
 export NETHERMIND_REPO=https://github.com/NethermindEth/nethermind.git
 export NETHERMIND_TAG=1.36.2

--- a/versions.json
+++ b/versions.json
@@ -1,7 +1,7 @@
 {
 	  "base_reth_node": {
-	  	  "tag": "v0.7.5",
-	  	  "commit": "497254884e5309994ee5bd1ba106efb36aaacd75",
+	  	  "tag": "v0.7.6",
+	  	  "commit": "5759d44b9384fd2ecde6c3fea6372e7c096e6267",
 	  	  "owner": "base",
 	  	  "repo": "base",
 	  	  "tracking": "release"


### PR DESCRIPTION
Update Base references in versions.json and versions.env to v0.7.6.

Release: https://github.com/base/base/releases/tag/v0.7.6