### PR TITLE
fix: default CLIENT to reth in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   execution:
     build:
       context: .
-      dockerfile: ${CLIENT:-geth}/Dockerfile
+      dockerfile: ${CLIENT:-reth}/Dockerfile
     restart: unless-stopped
     ports:
       - "8545:8545" # RPC
@@ -20,7 +20,7 @@ services:
   node:
     build:
       context: .
-      dockerfile: ${CLIENT:-geth}/Dockerfile
+      dockerfile: ${CLIENT:-reth}/Dockerfile
     restart: unless-stopped
     depends_on:
       - execution


### PR DESCRIPTION
## Problem

README.md documents `reth` as the default execution client:

> - `reth` (default)

But `docker-compose.yml` uses `geth` as the fallback:

```yaml
dockerfile: ${CLIENT:-geth}/Dockerfile
```

Running `docker compose up` without setting `CLIENT` silently starts `geth` instead of `reth`. This contradicts the documented default and, more critically, increases the risk of operators missing the Base V1 migration — after V1 activates (early May 2026), only `base-reth-node` will follow the canonical chain.

## Fix

Change the `CLIENT` fallback from `geth` to `reth` in both service definitions in `docker-compose.yml`. Operators who intentionally run `geth` can still do so by setting `CLIENT=geth` explicitly in their env file.

## Impact

- Fixes the inconsistency reported in #1010
- Reduces the risk of operators unknowingly running the wrong client ahead of V1 activation
- No breaking change — `CLIENT` override still works as before

Fixes #1010