### PR TITLE
fix(nethermind): skip NuGet audit to unblock CI

### DIFF
--- a/nethermind/Dockerfile
+++ b/nethermind/Dockerfile
@@ -29,7 +29,7 @@ RUN . /tmp/versions.env && git clone $NETHERMIND_REPO --branch $NETHERMIND_TAG -
 RUN TARGETARCH=${TARGETARCH#linux/} && \
     arch=$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH") && \
     echo "Using architecture: $arch" && \
-    dotnet publish src/Nethermind/Nethermind.Runner -c $BUILD_CONFIG -a $arch -o /publish --sc false
+    dotnet publish src/Nethermind/Nethermind.Runner -c $BUILD_CONFIG -a $arch -o /publish --sc false -p:NuGetAudit=false
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble
 


### PR DESCRIPTION
## Problem

The nethermind Docker build fails on every PR with:

```
error NU1904: Warning As Error: Package 'Microsoft.AspNetCore.DataProtection' 10.0.1
has a known critical severity vulnerability, GHSA-9mv3-2cwr-p262
```

A CVE was published against `Microsoft.AspNetCore.DataProtection` 10.0.1 **after** Nethermind 1.36.2 shipped. Since Nethermind enables `TreatWarningsAsErrors`, NuGet audit now hard-fails `dotnet restore` for ~40 projects in the dependency graph.

## Fix

Pass `-p:NuGetAudit=false` to `dotnet publish` in the nethermind Dockerfile. This is the standard workaround when an upstream dependency pins a vulnerable transitive package in its latest stable release.

## Upstream

Already patched in [NethermindEth/nethermind#11331](https://github.com/NethermindEth/nethermind/pull/11331), shipping in [1.37.0](https://github.com/NethermindEth/nethermind/releases/tag/1.37.0) (pre-release). When 1.37.0 goes stable, we bump `NETHERMIND_TAG` in `versions.env` and drop this flag.