### PR TITLE
ci: test dependency updater

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,6 +8,23 @@ permissions:
   contents: read
 
 jobs:
+  dependency-updater:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Test dependency updater
+        run: go test ./...
+        working-directory: dependency_updater
+
   geth:
     strategy:
       matrix:

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -20,6 +20,9 @@ jobs:
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: test dependency updater
+        run: cd dependency_updater && go test ./...
+
       - name: build dependency updater
         run: cd dependency_updater && go build
 


### PR DESCRIPTION
## Summary

Adds dependency updater tests to CI so changes to the updater are validated before merge.

- Run `go test ./...` for `dependency_updater` on pull requests
- Run the same test before building the updater in the scheduled dependency update workflow

## Testing

- `cd dependency_updater && go test ./...`
