### PR TITLE
chore: upgrade base/base to 0.8.0

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -1,6 +1,6 @@
-export BASE_RETH_NODE_COMMIT=5759d44b9384fd2ecde6c3fea6372e7c096e6267
+export BASE_RETH_NODE_COMMIT=3049ce2e3a5132f2ef74b4ba14a1a952ea6abdfb
 export BASE_RETH_NODE_REPO=https://github.com/base/base.git
-export BASE_RETH_NODE_TAG=v0.7.6
+export BASE_RETH_NODE_TAG=v0.8.0
 export NETHERMIND_COMMIT=f5507dec1c9c7f5e31dadae445c08622be166054
 export NETHERMIND_REPO=https://github.com/NethermindEth/nethermind.git
 export NETHERMIND_TAG=1.36.2

--- a/versions.json
+++ b/versions.json
@@ -1,7 +1,7 @@
 {
 	  "base_reth_node": {
-	  	  "tag": "v0.7.6",
-	  	  "commit": "5759d44b9384fd2ecde6c3fea6372e7c096e6267",
+	  	  "tag": "v0.8.0",
+	  	  "commit": "3049ce2e3a5132f2ef74b4ba14a1a952ea6abdfb",
 	  	  "owner": "base",
 	  	  "repo": "base",
 	  	  "tracking": "release"


### PR DESCRIPTION
## Summary
- upgrade base_reth_node from v0.7.6 to v0.8.0
- pin base/base to commit 3049ce2e3a5132f2ef74b4ba14a1a952ea6abdfb
