### PR TITLE
fix: add autorestart to supervisord for process resilience

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -8,6 +8,7 @@ command=/app/consensus-entrypoint
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 redirect_stderr=true
+autorestart=true
 stopwaitsecs=300
 
 [program:op-execution]
@@ -15,4 +16,5 @@ command=/app/execution-entrypoint
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 redirect_stderr=true
+autorestart=true
 stopwaitsecs=300


### PR DESCRIPTION
## Summary

Adds `autorestart=true` to both `[program:base-consensus]` and `[program:op-execution]` sections in `supervisord.conf`.

## Problem

By default, supervisord uses `autorestart=unexpected`, which only restarts a process when it exits with a non-zero exit code. This means that if a process is terminated gracefully (e.g., by a SIGTERM during a Docker daemon event or internal crash that returns 0), supervisord will not restart it, leaving the node partially or fully offline until manual intervention.

## Solution

Explicitly set `autorestart=true` for both programs. This ensures that the consensus and execution clients are automatically restarted regardless of how they exit, improving node reliability during long-running operations.

## Impact

- Improves operational resilience for node operators running the Docker setup.
- Reduces manual intervention when a client process terminates unexpectedly.

## Checklist

- [x] Change is minimal and focused.
- [x] No breaking changes to existing behavior.
- [x] Verified that supervisord syntax remains valid.