### PR TITLE
fix: add HOST_IP support to nethermind entrypoint

### DIFF
--- a/nethermind/nethermind-entrypoint
+++ b/nethermind/nethermind-entrypoint
@@ -42,6 +42,10 @@ if [[ -n "${OP_NETHERMIND_ETHSTATS_ENDPOINT:-}" ]]; then
     ADDITIONAL_ARGS="$ADDITIONAL_ARGS --EthStats.NodeName=${OP_NETHERMIND_ETHSTATS_NODE_NAME:-NethermindNode} --EthStats.Endpoint=$OP_NETHERMIND_ETHSTATS_ENDPOINT"
 fi
 
+if [ "${HOST_IP:+x}" = x ]; then
+    ADDITIONAL_ARGS="$ADDITIONAL_ARGS --Network.ExternalIp=$HOST_IP"
+fi
+
 # Execute Nethermind
 exec ./nethermind \
     --config="$OP_NODE_NETWORK" \


### PR DESCRIPTION
## Summary

Adds `HOST_IP` support to the nethermind execution client entrypoint, matching the existing behavior in the geth entrypoint.

## Problem

The `geth-entrypoint` script already respects the `HOST_IP` environment variable and passes `--nat=extip:$HOST_IP` to improve peer discoverability. However, the `nethermind-entrypoint` completely ignores `HOST_IP`, causing operators who choose the nethermind client to have worse peer connectivity.

## Solution

Add the same conditional check (`if [ "${HOST_IP:+x}" = x ]`) to the nethermind entrypoint and append `--Network.ExternalIp=$HOST_IP` to `ADDITIONAL_ARGS`.

## Impact

- Nethermind operators can now advertise their public IP for better P2P peer discovery.
- Behavior is consistent across supported execution clients (geth, nethermind).

## Checklist

- [x] Change is minimal and focused.
- [x] Follows the same pattern used in `geth-entrypoint`.
- [x] No breaking changes.