### PR TITLE
fix: add HOST_IP support to reth entrypoint

### DIFF
--- a/reth/reth-entrypoint
+++ b/reth/reth-entrypoint
@@ -126,6 +126,10 @@ if [[ "$RETH_HISTORICAL_PROOFS" == "true" && -n "$RETH_HISTORICAL_PROOFS_STORAGE
         --proofs-history.storage-path=$RETH_HISTORICAL_PROOFS_STORAGE_PATH
 fi
 
+if [ "${HOST_IP:+x}" = x ]; then
+    ADDITIONAL_ARGS="$ADDITIONAL_ARGS --nat=extip:$HOST_IP"
+fi
+
 mkdir -p "$RETH_DATA_DIR"
 echo "Starting reth with additional args: $ADDITIONAL_ARGS"
 echo "$BASE_NODE_L2_ENGINE_AUTH_RAW" > "$BASE_NODE_L2_ENGINE_AUTH"


### PR DESCRIPTION
## Summary

Adds `HOST_IP` support to the reth execution client entrypoint, completing parity with geth and nethermind.

## Problem

The `geth-entrypoint` has long supported `HOST_IP` via `--nat=extip`, and `nethermind-entrypoint` now supports it via `--Network.ExternalIp`. The `reth-entrypoint` is the only execution client that ignores `HOST_IP`, causing reth operators running behind NAT to have degraded peer discovery and lower peer counts.

## Solution

Add the same conditional check (`if [ "${HOST_IP:+x}" = x ]`) to the reth entrypoint and append `--nat=extip:$HOST_IP` to `ADDITIONAL_ARGS`.

## Verification

The `--nat=extip:<IP>` flag is a valid reth CLI argument. Verified against the upstream reth source code:

- `crates/node/core/src/args/network.rs` defines the `--nat` argument as a `NatResolver` with supported values: `any|none|upnp|publicip|extip:<IP>`.
- `crates/net/nat/src/lib.rs` implements `NatResolver::ExternalIp(IpAddr)`, which is the enum variant triggered by `--nat=extip:<IP>`.

References:
- https://github.com/paradigmxyz/reth/blob/main/crates/node/core/src/args/network.rs
- https://github.com/paradigmxyz/reth/blob/main/crates/net/nat/src/lib.rs

## Impact

- Reth operators can now advertise their public IP for better P2P peer discovery.
- All three supported execution clients (geth, nethermind, reth) behave consistently when `HOST_IP` is configured.

## Checklist

- [x] Change is minimal and focused.
- [x] Follows the same pattern used in `geth-entrypoint`.
- [x] Flag verified against upstream reth source code.
- [x] No breaking changes.