### PR TITLE
fix: add fallback default for HOST_DATA_DIR in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "30303:30303/udp" # P2P UDP
     command: ["bash", "./execution-entrypoint"]
     volumes:
-      - ${HOST_DATA_DIR}:/data
+      - ${HOST_DATA_DIR:-./data}:/data
     environment:
       - USE_BASE_CONSENSUS=${USE_BASE_CONSENSUS:-false}
     env_file:


### PR DESCRIPTION
## Summary

Adds a Compose-level fallback (`${HOST_DATA_DIR:-./data}`) for the execution service volume mount.

## Problem

`docker-compose.yml` mounts chain data using `${HOST_DATA_DIR}:/data`. If `HOST_DATA_DIR` is unset, Docker Compose expands the variable to an empty string and creates an anonymous volume. This leads to:

1. Chain data being stored in an opaque Docker-managed location.
2. Risk of accidental data loss when the volume is pruned.
3. Confusion for operators who expected data to persist to a local directory.

## Solution

Use `${HOST_DATA_DIR:-./data}` so that `./data` is used as a safe fallback when the variable is missing. This aligns with the default already documented in `.env.mainnet` and `.env.sepolia`.

## Impact

- Chain data is always persisted to a predictable local directory.
- No breaking change for operators who already set `HOST_DATA_DIR`.

## Checklist

- [x] Change is minimal and focused.
- [x] Follows the same fallback pattern used elsewhere (e.g., `${NETWORK_ENV:-.env.mainnet}`).
- [x] No breaking changes.