### PR TITLE
refactor: extract shared get_public_ip into helpers.sh

### DIFF
--- a/base-consensus-entrypoint
+++ b/base-consensus-entrypoint
@@ -1,26 +1,7 @@
 #!/bin/bash
 set -eu
 
-get_public_ip() {
-  # Define a list of HTTP-based providers
-  local PROVIDERS=(
-    "http://ifconfig.me"
-    "http://api.ipify.org"
-    "http://ipecho.net/plain"
-    "http://v4.ident.me"
-  )
-  # Iterate through the providers until an IP is found or the list is exhausted
-  for provider in "${PROVIDERS[@]}"; do
-    local IP
-    IP=$(curl -s --max-time 10 --connect-timeout 5 "$provider")
-    # Check if IP contains a valid format (simple regex for an IPv4 address)
-    if [[ $IP =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-      echo "$IP"
-      return 0
-    fi
-  done
-  return 1
-}
+source ./helpers.sh
 
 if [[ -z "${BASE_NODE_NETWORK:-}" ]]; then
   echo "expected BASE_NODE_NETWORK to be set" 1>&2

--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -40,5 +40,6 @@ COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY geth/geth-entrypoint ./execution-entrypoint
 COPY op-node-entrypoint .
 COPY consensus-entrypoint .
+COPY helpers.sh .
 
 CMD ["/usr/bin/supervisord"]

--- a/helpers.sh
+++ b/helpers.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Shared helper functions used by Base node entrypoints
+
+# get_public_ip attempts to discover the node's public IPv4 address
+# by querying a list of HTTP-based IP detection services.
+# Prints the IP to stdout and returns 0 on success, 1 on failure.
+get_public_ip() {
+  local PROVIDERS=(
+    "http://ifconfig.me"
+    "http://api.ipify.org"
+    "http://ipecho.net/plain"
+    "http://v4.ident.me"
+  )
+
+  for provider in "${PROVIDERS[@]}"; do
+    local IP
+    IP=$(curl -s --max-time 10 --connect-timeout 5 "$provider")
+    if [[ $IP =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+      echo "$IP"
+      return 0
+    fi
+  done
+  return 1
+}

--- a/nethermind/Dockerfile
+++ b/nethermind/Dockerfile
@@ -47,5 +47,6 @@ COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY nethermind/nethermind-entrypoint ./execution-entrypoint
 COPY op-node-entrypoint .
 COPY consensus-entrypoint .
+COPY helpers.sh .
 
 CMD ["/usr/bin/supervisord"]

--- a/op-node-entrypoint
+++ b/op-node-entrypoint
@@ -1,26 +1,7 @@
 #!/bin/bash
 set -eu
 
-get_public_ip() {
-  # Define a list of HTTP-based providers
-  local PROVIDERS=(
-    "http://ifconfig.me"
-    "http://api.ipify.org"
-    "http://ipecho.net/plain"
-    "http://v4.ident.me"
-  )
-  # Iterate through the providers until an IP is found or the list is exhausted
-  for provider in "${PROVIDERS[@]}"; do
-    local IP
-    IP=$(curl -s --max-time 10 --connect-timeout 5 "$provider")
-    # Check if IP contains a valid format (simple regex for an IPv4 address)
-    if [[ $IP =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-      echo "$IP"
-      return 0
-    fi
-  done
-  return 1
-}
+source ./helpers.sh
 
 if [[ -z "$OP_NODE_NETWORK" && -z "$OP_NODE_ROLLUP_CONFIG" ]]; then
   echo "expected OP_NODE_NETWORK to be set" 1>&2

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -71,5 +71,6 @@ COPY ./reth/reth-entrypoint ./execution-entrypoint
 COPY op-node-entrypoint .
 COPY base-consensus-entrypoint .
 COPY consensus-entrypoint .
+COPY helpers.sh .
 
 CMD ["/usr/bin/supervisord"]


### PR DESCRIPTION
## Summary

Eliminates 23-line duplication of `get_public_ip()` across `op-node-entrypoint` and `base-consensus-entrypoint` by moving it into a shared `helpers.sh` script.

## Problem

The `get_public_ip()` bash function was copy-pasted verbatim in two entrypoints. This violates DRY:
- Any bug fix or provider list change must be edited twice.
- The two copies can silently diverge over time.

## Solution

1. Create `helpers.sh` containing a single, documented `get_public_ip` implementation.
2. Replace inline definitions with `source ./helpers.sh` in both entrypoints.
3. Add `COPY helpers.sh .` to `geth`, `reth`, and `nethermind` Dockerfiles so the helper is present in all final images.

## Files Changed

| File | Change |
|------|--------|
| `helpers.sh` | **New** — shared helper library |
| `op-node-entrypoint` | Remove inline `get_public_ip`, add `source ./helpers.sh` |
| `base-consensus-entrypoint` | Same as above |
| `geth/Dockerfile` | `COPY helpers.sh .` |
| `reth/Dockerfile` | `COPY helpers.sh .` |
| `nethermind/Dockerfile` | `COPY helpers.sh .` |

## Verification

- `get_public_ip` is still callable from both entrypoints.
- Docker build context includes `helpers.sh` at repo root, so all `COPY` instructions resolve.
- No functional change; behavior is identical.

## Impact

- Reduces maintenance burden for future IP-detection changes.
- Establishes a pattern for shared helper functions across entrypoints.

## Checklist

- [x] Refactor only — no functional changes.
- [x] All three client Dockerfiles updated.
- [x] Verified that `source ./helpers.sh` resolves inside the container (`/app`).