### PR TITLE
fix: remove orphan root go.mod that shadows dependency_updater module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,0 @@
-module dependency_updater
-
-go 1.24.3


### PR DESCRIPTION
## Summary
Removes an unnecessary go.mod file from the repository root.

## Problem
The orphan file was shadowing the actual module in the subdirectory, causing issues with Go tools.

## Solution
Deleted root go.mod.

## Verification
- Confirmed Go tools now resolve correctly.

## Impact
Cleaner repo structure.