### PR TITLE
fix: add wildcard to apt-lists cleanup in geth Dockerfile

### DIFF
--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -29,7 +29,7 @@ FROM ubuntu:24.04
 
 RUN apt-get update && \
     apt-get install -y jq curl supervisor && \
-    rm -rf /var/lib/apt/lists
+    rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /var/log/supervisor
 
 WORKDIR /app


### PR DESCRIPTION
## Summary
Fixes the apt-lists cleanup pattern in the Geth Dockerfile to prevent directory removal.

## Problem
Removing the entire lists directory breaks subsequent apt operations in derived images.

## Solution
Changed to rm -rf /var/lib/apt/lists/*.

## Verification
- Confirmed directory remains present.

## Impact
Ensures more robust Docker builds.