### PR TITLE
fix: add autorestart to supervisord for process resilience

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -5,6 +5,7 @@ logfile_maxbytes=0
 
 [program:base-consensus]
 command=/app/consensus-entrypoint
+autorestart=true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 redirect_stderr=true
@@ -12,6 +13,7 @@ stopwaitsecs=300
 
 [program:op-execution]
 command=/app/execution-entrypoint
+autorestart=true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 redirect_stderr=true


### PR DESCRIPTION
## Summary
Enables autorestart=true for all programs in supervisord.conf to ensure process resilience.

## Problem
Processes could stay down after a graceful shutdown or a non-zero exit, leading to silent downtime.

## Solution
Added autorestart=true to both [program:base-consensus] and [program:op-execution] sections.

## Verification
- Verified that supervisord now automatically restarts the processes.

## Impact
Significantly increases the uptime and self-healing capability of the node infrastructure.