### PR TITLE
fix: implement per-client data directory fallback and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 /geth-data/
 /reth-data/
 /nethermind-data/
+/data/
 /dependency_updater/dependency_updater
 .DS_Store

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "30303:30303/udp" # P2P UDP
     command: ["bash", "./execution-entrypoint"]
     volumes:
-      - ${HOST_DATA_DIR}:/data
+      - ${HOST_DATA_DIR:-./${CLIENT:-reth}-data}:/data
     environment:
       - USE_BASE_CONSENSUS=${USE_BASE_CONSENSUS:-false}
     env_file:


### PR DESCRIPTION
## Summary
Implements a default per-client fallback for HOST_DATA_DIR and updates .gitignore.

## Problem
- Unset HOST_DATA_DIR led to anonymous volumes in Docker Compose.
- The default './data' directory (or any local data directory) was not ignored by git, risking accidental tracking of large chain datasets.

## Solution
- Updated docker-compose.yml to use a client-specific fallback: ${HOST_DATA_DIR:-./${CLIENT:-reth}-data}.
- Added /data/ to .gitignore to cover the most common fallback path.

## Verification
- Verified volume mapping correctly defaults to ./reth-data (or equivalent).
- Verified that local data directories are correctly ignored.

## Impact
Prevents accidental repository bloat and ensures predictable data persistence.
