### PR TITLE
fix: quote unquoted variables flagged by ShellCheck SC2086

### DIFF
--- a/geth/geth-entrypoint
+++ b/geth/geth-entrypoint
@@ -26,7 +26,7 @@ if [[ -z "$OP_NODE_NETWORK" ]]; then
     exit 1
 fi
 
-mkdir -p $GETH_DATA_DIR
+mkdir -p "$GETH_DATA_DIR"
 
 echo "$BASE_NODE_L2_ENGINE_AUTH_RAW" > "$BASE_NODE_L2_ENGINE_AUTH"
 

--- a/nethermind/nethermind-entrypoint
+++ b/nethermind/nethermind-entrypoint
@@ -46,7 +46,7 @@ fi
 exec ./nethermind \
     --config="$OP_NODE_NETWORK" \
     --datadir="$NETHERMIND_DATA_DIR" \
-    --Optimism.SequencerUrl=$OP_SEQUENCER_HTTP \
+    --Optimism.SequencerUrl="$OP_SEQUENCER_HTTP" \
     --log="$NETHERMIND_LOG_LEVEL" \
     --JsonRpc.Enabled=true \
     --JsonRpc.Host=0.0.0.0 \

--- a/reth/reth-entrypoint
+++ b/reth/reth-entrypoint
@@ -123,7 +123,7 @@ if [[ "$RETH_HISTORICAL_PROOFS" == "true" && -n "$RETH_HISTORICAL_PROOFS_STORAGE
         --log.stdout.format json \
         --chain "$RETH_CHAIN" \
         --datadir="$RETH_DATA_DIR" \
-        --proofs-history.storage-path=$RETH_HISTORICAL_PROOFS_STORAGE_PATH
+        --proofs-history.storage-path="$RETH_HISTORICAL_PROOFS_STORAGE_PATH"
 fi
 
 mkdir -p "$RETH_DATA_DIR"


### PR DESCRIPTION
- fix(reth-entrypoint): quote RETH_HISTORICAL_PROOFS_STORAGE_PATH
- fix(geth-entrypoint): quote GETH_DATA_DIR in mkdir -p
- fix(nethermind-entrypoint): quote OP_SEQUENCER_HTTP

ShellCheck now only flags the 3 intentionally unquoted uses (word splitting required for multiple args).