### PR TITLE
feat: make max peer count configurable via environment variables

### DIFF
--- a/.env.mainnet
+++ b/.env.mainnet
@@ -120,3 +120,9 @@ STATSD_ADDRESS="172.17.0.1"
 # NOTE: The node type that was chosen when first running a node cannot be changed after the initial sync. Turning Archive into Pruned, or Pruned into Full is not supported [source](https://reth.rs/run/faq/pruning/).
 # NOTE: The pruned snapshots provided are set with a distance of 1_339_200 (~31 days).
 # RETH_PRUNING_ARGS="--prune.senderrecovery.distance=50000 --prune.transactionlookup.distance=50000 --prune.receipts.distance=50000 --prune.accounthistory.distance=50000 --prune.storagehistory.distance=50000 --prune.bodies.distance=50000"
+
+# PEER CONFIGURATION (OPTIONAL)
+# ----------------------------
+# RETH_MAX_OUTBOUND_PEERS=100
+# RETH_MAX_INBOUND_PEERS=30
+# GETH_MAX_PEERS=100

--- a/geth/geth-entrypoint
+++ b/geth/geth-entrypoint
@@ -11,6 +11,7 @@ HOST_IP="" # put your external IP address here and open port 30303 to improve pe
 P2P_PORT="${P2P_PORT:-30303}"
 DISCOVERY_PORT="${DISCOVERY_PORT:-30303}"
 ADDITIONAL_ARGS=""
+GETH_MAX_PEERS="${GETH_MAX_PEERS:-100}"
 OP_GETH_GCMODE="${OP_GETH_GCMODE:-full}"
 OP_GETH_SYNCMODE="${OP_GETH_SYNCMODE:-full}"
 
@@ -73,7 +74,7 @@ exec ./geth \
     --metrics.port="$METRICS_PORT" \
     --syncmode="$OP_GETH_SYNCMODE" \
     --gcmode="$OP_GETH_GCMODE" \
-    --maxpeers=100 \
+    --maxpeers="$GETH_MAX_PEERS" \
     --rollup.sequencerhttp="$OP_GETH_SEQUENCER_HTTP" \
     --rollup.halt=major \
     --op-network="$OP_NODE_NETWORK" \

--- a/reth/reth-entrypoint
+++ b/reth/reth-entrypoint
@@ -14,6 +14,8 @@ BINARY="./base-reth-node"
 RETH_HISTORICAL_PROOFS="${RETH_HISTORICAL_PROOFS:-false}"
 RETH_HISTORICAL_PROOFS_STORAGE_PATH="${RETH_HISTORICAL_PROOFS_STORAGE_PATH:-}"
 LOG_LEVEL="${LOG_LEVEL:-info}"
+RETH_MAX_OUTBOUND_PEERS="${RETH_MAX_OUTBOUND_PEERS:-100}"
+RETH_MAX_INBOUND_PEERS="${RETH_MAX_INBOUND_PEERS:-30}"
 
 if [[ -z "${RETH_CHAIN:-}" ]]; then
     echo "expected RETH_CHAIN to be set" 1>&2
@@ -149,7 +151,7 @@ exec "$BINARY" node \
   --authrpc.port="$AUTHRPC_PORT" \
   --authrpc.jwtsecret="$BASE_NODE_L2_ENGINE_AUTH" \
   --metrics=0.0.0.0:"$METRICS_PORT" \
-  --max-outbound-peers=100 \
+  --max-outbound-peers="$RETH_MAX_OUTBOUND_PEERS" \
   --chain "$RETH_CHAIN" \
   --rollup.sequencer-http="$RETH_SEQUENCER_HTTP" \
   --rollup.disable-tx-pool-gossip \


### PR DESCRIPTION
- Add RETH_MAX_OUTBOUND_PEERS (default 100) and RETH_MAX_INBOUND_PEERS (default 30) to reth-entrypoint
- Add GETH_MAX_PEERS (default 100) to geth-entrypoint
- Document new variables in .env.mainnet

This allows users to increase peer limits when experiencing gossipsub send queue issues (e.g., base/node#1063) or to reduce them on resource-constrained systems.