### PR TITLE
docs(reth): clarify Sepolia websocket config

### DIFF
--- a/reth/README.md
+++ b/reth/README.md
@@ -6,7 +6,7 @@ This is an implementation of the Reth node setup that supports Flashblocks mode 
 
 - See hardware requirements mentioned in the master README
 - For Flashblocks mode: Access to a Flashblocks websocket endpoint (for `RETH_FB_WEBSOCKET_URL`)
-  - We provide public websocket endpoints for mainnet and devnet, included in `.env.mainnet` and `.env.sepolia`
+  - We provide public websocket endpoints for mainnet and Sepolia, included in `.env.mainnet` and `.env.sepolia`
 
 ## Node Type Selection
 


### PR DESCRIPTION
## Summary
- update the Reth README to reference Sepolia instead of devnet
- keep the wording aligned with the shipped `.env.mainnet` and `.env.sepolia` files

## Testing
- not run (README-only change)
