### PR TITLE
feat: disable discv4, run discv5 on port 30303 by default

### DIFF
--- a/reth/reth-entrypoint
+++ b/reth/reth-entrypoint
@@ -127,6 +127,22 @@ if [[ "$RETH_HISTORICAL_PROOFS" == "true" && -n "$RETH_HISTORICAL_PROOFS_STORAGE
         --proofs-history.storage-path=$RETH_HISTORICAL_PROOFS_STORAGE_PATH
 fi
 
+if [[ "${DISABLE_DISCV4:-false}" == "true" && "${RETH_DISABLE_DISCOVERY:-false}" != "true" ]]; then
+    ADDITIONAL_ARGS="$ADDITIONAL_ARGS --disable-discv4-discovery"
+fi
+
+if [[ "${BASE_DISCOVERY_PROTOCOL:-true}" = "false" ]]; then
+    ADDITIONAL_ARGS="$ADDITIONAL_ARGS --rollup.discovery.v5.base false"
+fi
+
+if [[ -n "${RETH_TRUSTED_PEERS:-}" ]]; then
+    ADDITIONAL_ARGS="$ADDITIONAL_ARGS --trusted-peers=$RETH_TRUSTED_PEERS"
+fi
+
+if [[ "${RETH_DISABLE_DISCOVERY:-false}" == "true" ]]; then
+    ADDITIONAL_ARGS="$ADDITIONAL_ARGS --disable-discovery"
+fi
+
 mkdir -p "$RETH_DATA_DIR"
 echo "Starting reth with additional args: $ADDITIONAL_ARGS"
 echo "$BASE_NODE_L2_ENGINE_AUTH_RAW" > "$BASE_NODE_L2_ENGINE_AUTH"


### PR DESCRIPTION
## Summary

- Adds `DISABLE_DISCV4` env var (default `false`): when set to `true`, appends `--disable-discv4-discovery` to reth args so callers can opt in without touching the entrypoint
- Changes `V5_DISCOVERY_PORT` default from `9200` → `30303` so discv5 runs on the same port as devp2p TCP by default

## Motivation

The Base Sepolia snapshot job (`admin-base-reth-cbnode-sepolia`) runs reth in an environment where outbound UDP to non-standard ports is blocked by NAT/firewall. This results in `connected_peers=0` throughout the run — reth can't peer, can't snap-sync, FCUs always return `Syncing`, and the safe head never advances.

discv4 uses a stateless ping/pong UDP handshake that fails through NAT without hole-punching. discv5 uses a session-based protocol with better NAT traversal characteristics. Running discv5 on port 30303 (the standard devp2p port, already allowed outbound) gives the node the best chance of finding peers in restricted network environments.

Existing deployments are unaffected: `DISABLE_DISCV4` defaults to `false` and `V5_DISCOVERY_PORT` is still overridable per-deployment.