### PR TITLE
docs(readme): add 'Tracked on web3-discover' badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # Base Node
 
+[![Tracked on web3-discover](https://web3-discover.vercel.app/badge/base-coinbase-l2.svg)](https://web3-discover.vercel.app/airdrops/base-coinbase-l2)
+
 Base is a secure, low-cost, developer-friendly Ethereum L2 built on Optimism's [OP Stack](https://docs.optimism.io/). This repository contains Docker builds to run your own node on the Base network.
 
 [![Website base.org](https://img.shields.io/website-up-down-green-red/https/base.org.svg)](https://base.org)


### PR DESCRIPTION
Hi — this adds a small README badge linking to this project's listing on **[web3-discover](https://web3-discover.vercel.app)**, an honest hand-curated directory of currently-active airdrops and on-chain incentive programs (no paid placements, scam-filtered, risk-flagged).

The listing for this project: https://web3-discover.vercel.app/airdrops/base-coinbase-l2

The badge renders as:
> [![Tracked on web3-discover](https://web3-discover.vercel.app/badge/base-coinbase-l2.svg)](https://web3-discover.vercel.app/airdrops/base-coinbase-l2)

It's a single line near the top of the README and doesn't touch anything else. If you'd rather not host a third-party badge here, no problem — please feel free to close. I won't follow up.

— [@west0nG](https://github.com/west0nG)