### PR TITLE
docs: document Reth port and log level variables in env files

### DIFF
--- a/.env.mainnet
+++ b/.env.mainnet
@@ -48,6 +48,22 @@ STATSD_ADDRESS="172.17.0.1"
 # FLASHBLOCKS (OPTIONAL - UNCOMMENT TO ENABLE)
 # RETH_FB_WEBSOCKET_URL=wss://mainnet.flashblocks.base.org/ws
 
+# PORT CONFIGURATION (OPTIONAL - UNCOMMENT TO OVERRIDE DEFAULTS)
+# ---------------------------------------------------------------
+# Override default ports when running multiple nodes or to resolve conflicts.
+# RPC_PORT=8545          # HTTP JSON-RPC port
+# WS_PORT=8546           # WebSocket JSON-RPC port
+# AUTHRPC_PORT=8551      # Engine API (authenticated RPC) port
+# METRICS_PORT=6060      # Prometheus metrics port
+# DISCOVERY_PORT=30303   # P2P discovery port
+# V5_DISCOVERY_PORT=9200 # discv5 discovery port
+# P2P_PORT=30303         # P2P TCP port
+
+# LOG LEVEL (OPTIONAL - UNCOMMENT TO OVERRIDE DEFAULT)
+# -----------------------------------------------------
+# Supported values: error, warn, info, debug, trace (default: info)
+# LOG_LEVEL=info
+
 # PRUNING (OPTIONAL - UNCOMMENT TO ENABLE)
 # NOTE: Set to any number of blocks you want, but it should be >10064
 # NOTE: The node type that was chosen when first running a node cannot be changed after the initial sync. Turning Archive into Pruned, or Pruned into Full is not supported [source](https://reth.rs/run/faq/pruning/).

--- a/.env.sepolia
+++ b/.env.sepolia
@@ -48,6 +48,22 @@ STATSD_ADDRESS="172.17.0.1"
 # FLASHBLOCKS (OPTIONAL - UNCOMMENT TO ENABLE)
 # RETH_FB_WEBSOCKET_URL=wss://sepolia.flashblocks.base.org/ws
 
+# PORT CONFIGURATION (OPTIONAL - UNCOMMENT TO OVERRIDE DEFAULTS)
+# ---------------------------------------------------------------
+# Override default ports when running multiple nodes or to resolve conflicts.
+# RPC_PORT=8545          # HTTP JSON-RPC port
+# WS_PORT=8546           # WebSocket JSON-RPC port
+# AUTHRPC_PORT=8551      # Engine API (authenticated RPC) port
+# METRICS_PORT=6060      # Prometheus metrics port
+# DISCOVERY_PORT=30303   # P2P discovery port
+# V5_DISCOVERY_PORT=9200 # discv5 discovery port
+# P2P_PORT=30303         # P2P TCP port
+
+# LOG LEVEL (OPTIONAL - UNCOMMENT TO OVERRIDE DEFAULT)
+# -----------------------------------------------------
+# Supported values: error, warn, info, debug, trace (default: info)
+# LOG_LEVEL=info
+
 # PRUNING (OPTIONAL - UNCOMMENT TO ENABLE)
 # NOTE: Set to any number of blocks you want, but it should be >10064
 # NOTE: The node type that was chosen when first running a node cannot be changed after the initial sync. Turning Archive into Pruned, or Pruned into Full is not supported [source](https://reth.rs/run/faq/pruning/).


### PR DESCRIPTION
## Summary

Adds commented-out documentation for Reth-specific port and log level variables that are supported by `reth-entrypoint` but were completely absent from the env files.

## Problem

Operators who want to customize Reth ports (e.g. running multiple nodes, resolving port conflicts) or change log verbosity had no way to discover these variables without reading the entrypoint source code directly.

## Changes

Added documented, commented-out entries to both `.env.mainnet` and `.env.sepolia`:

| Variable | Default | Description |
|---|---|---|
| `RPC_PORT` | `8545` | HTTP JSON-RPC port |
| `WS_PORT` | `8546` | WebSocket JSON-RPC port |
| `AUTHRPC_PORT` | `8551` | Engine API (authenticated RPC) port |
| `METRICS_PORT` | `6060` | Prometheus metrics port |
| `DISCOVERY_PORT` | `30303` | P2P discovery port |
| `V5_DISCOVERY_PORT` | `9200` | discv5 discovery port |
| `P2P_PORT` | `30303` | P2P TCP port |
| `LOG_LEVEL` | `info` | Reth log verbosity (error/warn/info/debug/trace) |

## Verification

All variables verified against `reth/reth-entrypoint` source.