### PR TITLE
docs: clean up broken callout, dead links, and outdated wording

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,5 +52,5 @@ All support requests must be made via [our support team][3].
 
 [1]: https://github.com/base/node/issues
 [2]: https://medium.com/brigade-engineering/the-secrets-to-great-commit-messages-106fc0a92a25
-[3]: https://support.coinbase.com/customer/en/portal/articles/2288496-how-can-i-contact-coinbase-support-
+[3]: https://help.coinbase.com/
 

--- a/README.md
+++ b/README.md
@@ -70,15 +70,6 @@ The following are the hardware specifications we use in production:
 - **Storage**: RAID 0 of all local NVMe drives (`/dev/nvme*`)
 - **Filesystem**: ext4
 
-> [!NOTE]
-To run the node using a supported client, you can use the following command:
-`CLIENT=supported_client docker compose up --build`
- 
-Supported clients:
- - reth (runs vanilla node by default, Flashblocks mode enabled by providing RETH_FB_WEBSOCKET_URL, see [Reth Node README](./reth/README.md))
- - geth
- - nethermind
-
 ## Configuration
 
 ### Required Settings

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,7 +31,7 @@ program, view our [security program policies][7].
 [2]: https://hackerone.com/coinbase?type=team 
 [3]: https://docs.optimism.io/
 [4]: https://immunefi.com/bounty/optimism/
-[5]: https://docs.optimism.io/docs/releases/bedrock/
+[5]: https://docs.optimism.io/stack/getting-started
 [6]: https://hackerone.com/coinbase
 [7]: https://hackerone.com/coinbase?view_policy=true
 

--- a/reth/README.md
+++ b/reth/README.md
@@ -4,7 +4,7 @@ This is an implementation of the Reth node setup that supports Flashblocks mode 
 
 ## Setup
 
-- See hardware requirements mentioned in the master README
+- See hardware requirements in the root README
 - For Flashblocks mode: Access to a Flashblocks websocket endpoint (for `RETH_FB_WEBSOCKET_URL`)
   - We provide public websocket endpoints for mainnet and devnet, included in `.env.mainnet` and `.env.sepolia`
 
@@ -17,7 +17,7 @@ The node determines its mode based on the presence of the `RETH_FB_WEBSOCKET_URL
 
 ## Running the Node
 
-The node follows the standard `docker compose` workflow in the master README.
+The node follows the standard `docker compose` workflow in the root README.
 
 ```bash
 # To run Reth node with Flashblocks support, set RETH_FB_WEBSOCKET_URL in your .env file


### PR DESCRIPTION
## Summary

Four small but real documentation fixes across the repo.

## Changes

### 1. `README.md` — Remove broken `[!NOTE]` callout block

The callout marker `> [!NOTE]` was followed by lines that did not start with the `>` prefix, breaking the GitHub callout syntax:

```diff
- > [!NOTE]
- To run the node using a supported client, you can use the following command:
- `CLIENT=supported_client docker compose up --build`
-
- Supported clients:
-  - reth (runs vanilla node by default...)
-  - geth
-  - nethermind
```

The same information is already present in the **Quick Start** (lines 34-38) and **Supported Clients** (lines 41-45) sections immediately above, so the redundant block was removed entirely.

### 2. `reth/README.md` — Replace "master README" with "root README"

```diff
- See hardware requirements mentioned in the master README
+ See hardware requirements in the root README

- The node follows the standard docker compose workflow in the master README.
+ The node follows the standard docker compose workflow in the root README.
```

"master" as a hierarchy term is ambiguous — readers might wonder if it refers to a branch name. "root README" is unambiguous and matches modern open source conventions.

### 3. `CONTRIBUTING.md` — Update deprecated Coinbase support URL

```diff
- https://support.coinbase.com/customer/en/portal/articles/2288496-how-can-i-contact-coinbase-support-
+ https://help.coinbase.com/
```

The old Zendesk-style `/customer/en/portal/articles/` URL format has been retired. The modern entry point is `help.coinbase.com`.

### 4. `SECURITY.md` — Update dead OP Stack docs link

```diff
- [5]: https://docs.optimism.io/docs/releases/bedrock/
+ [5]: https://docs.optimism.io/stack/getting-started
```

The `/docs/releases/bedrock/` path no longer exists in the current OP Stack documentation. Updated to the current canonical path.

## Verification

- ✅ All four changes verified locally
- ✅ Replacement URLs all confirmed to load correctly
- ✅ README content preserved (duplicate block removed, not unique info)