### PR TITLE
fix(reth): correct devnet to sepolia in README Flashblocks endpoint description

### DIFF
--- a/reth/README.md
+++ b/reth/README.md
@@ -6,7 +6,7 @@ This is an implementation of the Reth node setup that supports Flashblocks mode 
 
 - See hardware requirements mentioned in the master README
 - For Flashblocks mode: Access to a Flashblocks websocket endpoint (for `RETH_FB_WEBSOCKET_URL`)
-  - We provide public websocket endpoints for mainnet and devnet, included in `.env.mainnet` and `.env.sepolia`
+  - We provide public websocket endpoints for mainnet and sepolia, included in `.env.mainnet` and `.env.sepolia`
 
 ## Node Type Selection
 


### PR DESCRIPTION
## Summary

Fixes a terminology error in `reth/README.md` reported in #1075.

## Problem

The Setup section says:
> We provide public websocket endpoints for mainnet and **devnet**

But the correct term is **sepolia**, consistent with:
- The actual endpoint: `wss://sepolia.flashblocks.base.org/ws`
- The env file name: `.env.sepolia`

## Fix

One-word change: `devnet` → `sepolia`

Fixes #1075