### PR TITLE
feat: make max-outbound-peers configurable via MAX_OUTBOUND_PEERS env var

### DIFF
--- a/.env.mainnet
+++ b/.env.mainnet
@@ -48,6 +48,12 @@ STATSD_ADDRESS="172.17.0.1"
 # FLASHBLOCKS (OPTIONAL - UNCOMMENT TO ENABLE)
 # RETH_FB_WEBSOCKET_URL=wss://mainnet.flashblocks.base.org/ws
 
+# PEER LIMITS (OPTIONAL - UNCOMMENT TO OVERRIDE DEFAULTS)
+# --------------------------------------------------------
+# Increase MAX_OUTBOUND_PEERS if you see persistent "Send Queue full" warnings.
+# See: https://github.com/base/node/issues/1063
+# MAX_OUTBOUND_PEERS=100
+
 # PRUNING (OPTIONAL - UNCOMMENT TO ENABLE)
 # NOTE: Set to any number of blocks you want, but it should be >10064
 # NOTE: The node type that was chosen when first running a node cannot be changed after the initial sync. Turning Archive into Pruned, or Pruned into Full is not supported [source](https://reth.rs/run/faq/pruning/).

--- a/.env.sepolia
+++ b/.env.sepolia
@@ -48,6 +48,12 @@ STATSD_ADDRESS="172.17.0.1"
 # FLASHBLOCKS (OPTIONAL - UNCOMMENT TO ENABLE)
 # RETH_FB_WEBSOCKET_URL=wss://sepolia.flashblocks.base.org/ws
 
+# PEER LIMITS (OPTIONAL - UNCOMMENT TO OVERRIDE DEFAULTS)
+# --------------------------------------------------------
+# Increase MAX_OUTBOUND_PEERS if you see persistent "Send Queue full" warnings.
+# See: https://github.com/base/node/issues/1063
+# MAX_OUTBOUND_PEERS=100
+
 # PRUNING (OPTIONAL - UNCOMMENT TO ENABLE)
 # NOTE: Set to any number of blocks you want, but it should be >10064
 # NOTE: The node type that was chosen when first running a node cannot be changed after the initial sync. Turning Archive into Pruned, or Pruned into Full is not supported [source](https://reth.rs/run/faq/pruning/).

--- a/execution-entrypoint
+++ b/execution-entrypoint
@@ -10,6 +10,7 @@ METRICS_PORT="${METRICS_PORT:-6060}"
 DISCOVERY_PORT="${DISCOVERY_PORT:-30303}"
 V5_DISCOVERY_PORT="${V5_DISCOVERY_PORT:-9200}"
 P2P_PORT="${P2P_PORT:-30303}"
+MAX_OUTBOUND_PEERS="${MAX_OUTBOUND_PEERS:-100}"
 ADDITIONAL_ARGS=""
 BINARY="./base-reth-node"
 RETH_HISTORICAL_PROOFS="${RETH_HISTORICAL_PROOFS:-false}"
@@ -150,7 +151,7 @@ exec "$BINARY" node \
   --authrpc.port="$AUTHRPC_PORT" \
   --authrpc.jwtsecret="$BASE_NODE_L2_ENGINE_AUTH" \
   --metrics=0.0.0.0:"$METRICS_PORT" \
-  --max-outbound-peers=100 \
+  --max-outbound-peers="$MAX_OUTBOUND_PEERS" \
   --chain "$RETH_CHAIN" \
   --rollup.sequencer-http="$RETH_SEQUENCER_HTTP" \
   --rollup.disable-tx-pool-gossip \


### PR DESCRIPTION
## Summary

Makes the Reth `--max-outbound-peers` flag configurable via a `MAX_OUTBOUND_PEERS` environment variable instead of being hardcoded to `100`.

## Problem

Operators experiencing persistent `Send Queue full` gossipsub warnings (#1063) need to increase the outbound peer limit to resolve the issue. However, `--max-outbound-peers=100` was hardcoded in `reth-entrypoint` with no way to override it without modifying the entrypoint script directly.

## Changes

- `reth/reth-entrypoint`: Replace hardcoded `--max-outbound-peers=100` with `$MAX_OUTBOUND_PEERS` (default: `100`, preserving existing behaviour)
- `.env.mainnet` and `.env.sepolia`: Document `MAX_OUTBOUND_PEERS` with usage guidance and reference to #1063

## Behaviour

No change for existing operators — default remains `100`. Operators who need more peers can now set:

```bash
MAX_OUTBOUND_PEERS=250 docker compose up
```

Closes #1063 (partially)