### PR TITLE
fix: remove hardcoded Engine API JWT secret and require explicit configuration

### DIFF
--- a/.env.mainnet
+++ b/.env.mainnet
@@ -21,7 +21,8 @@ BASE_NODE_L1_TRUST_RPC="false"
 # --------------------
 BASE_NODE_L2_ENGINE_RPC=ws://execution:8551
 BASE_NODE_L2_ENGINE_AUTH=/tmp/engine-auth-jwt
-BASE_NODE_L2_ENGINE_AUTH_RAW=688f5d737bad920bdfb2fc2f488d6b6209eebda1dae949a8de91398d932c517a
+# [REQUIRED] Generate with: openssl rand -hex 32
+BASE_NODE_L2_ENGINE_AUTH_RAW=<your-secret-jwt>
 
 # P2P CONFIGURATION
 # -----------------

--- a/.env.sepolia
+++ b/.env.sepolia
@@ -21,7 +21,8 @@ BASE_NODE_L1_TRUST_RPC="false"
 # --------------------
 BASE_NODE_L2_ENGINE_RPC=http://execution:8551
 BASE_NODE_L2_ENGINE_AUTH=/tmp/engine-auth-jwt
-BASE_NODE_L2_ENGINE_AUTH_RAW=688f5d737bad920bdfb2fc2f488d6b6209eebda1dae949a8de91398d932c517a
+# [REQUIRED] Generate with: openssl rand -hex 32
+BASE_NODE_L2_ENGINE_AUTH_RAW=<your-secret-jwt>
 
 # P2P CONFIGURATION
 # -----------------

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ The following are the hardware specifications we use in production:
 - `BASE_NODE_L1_BEACON`: your L1 beacon node endpoint
 - `BASE_NODE_NETWORK`: `base` or `base-sepolia`
 - `RETH_CHAIN`: `base` or `base-sepolia`
+- `BASE_NODE_L2_ENGINE_AUTH_RAW`: a 32-byte hex secret shared between the execution and consensus containers — **never use the placeholder value**. Generate with:
+  ```bash
+  openssl rand -hex 32
+  ```
 
 ### Network Settings
 

--- a/consensus-entrypoint
+++ b/consensus-entrypoint
@@ -36,8 +36,10 @@ if [[ -z "${BASE_NODE_L2_ENGINE_AUTH:-}" ]]; then
   exit 1
 fi
 
-if [[ -z "${BASE_NODE_L2_ENGINE_AUTH_RAW:-}" ]]; then
-  echo "expected BASE_NODE_L2_ENGINE_AUTH_RAW to be set" 1>&2
+if [[ -z "${BASE_NODE_L2_ENGINE_AUTH_RAW:-}" || "${BASE_NODE_L2_ENGINE_AUTH_RAW}" == "<your-secret-jwt>" ]]; then
+  echo "ERROR: BASE_NODE_L2_ENGINE_AUTH_RAW is not set or still uses the placeholder value." >&2
+  echo "Generate a secret and set it in your .env file:" >&2
+  echo "  BASE_NODE_L2_ENGINE_AUTH_RAW=\$(openssl rand -hex 32)" >&2
   exit 1
 fi
 

--- a/execution-entrypoint
+++ b/execution-entrypoint
@@ -129,6 +129,13 @@ fi
 
 mkdir -p "$RETH_DATA_DIR"
 echo "Starting reth with additional args: $ADDITIONAL_ARGS"
+
+if [[ -z "${BASE_NODE_L2_ENGINE_AUTH_RAW:-}" || "${BASE_NODE_L2_ENGINE_AUTH_RAW}" == "<your-secret-jwt>" ]]; then
+    echo "ERROR: BASE_NODE_L2_ENGINE_AUTH_RAW is not set or still uses the placeholder value." >&2
+    echo "Generate a secret and set it in your .env file:" >&2
+    echo "  BASE_NODE_L2_ENGINE_AUTH_RAW=\$(openssl rand -hex 32)" >&2
+    exit 1
+fi
 echo "$BASE_NODE_L2_ENGINE_AUTH_RAW" > "$BASE_NODE_L2_ENGINE_AUTH"
 
 exec "$BINARY" node \


### PR DESCRIPTION
## Summary

Fixes #1086.

The default `BASE_NODE_L2_ENGINE_AUTH_RAW` value (`688f5d737bad920b...`) was a well-known public hex string committed in the repository. Since `authrpc` binds to `0.0.0.0:8551`, any operator using host networking, Kubernetes, custom port mappings, or shared Docker networks was exposed to unauthenticated Engine API access.

## ⚠️ Breaking Change

Operators who relied on the default `BASE_NODE_L2_ENGINE_AUTH_RAW` value must now set their own secret before starting the node. The entrypoints will exit with a clear error message and generation hint if the variable is unset or still holds the placeholder:

```
ERROR: BASE_NODE_L2_ENGINE_AUTH_RAW is not set or still uses the default placeholder.
Please generate a secure secret and set it in your .env file:
  export BASE_NODE_L2_ENGINE_AUTH_RAW=$(openssl rand -hex 32)
```

## Changes

- `.env.mainnet` / `.env.sepolia`: Replace hardcoded secret with `<your-secret-jwt>` placeholder and generation instructions
- `reth/reth-entrypoint`, `base-consensus-entrypoint`, `geth/geth-entrypoint`, `op-node-entrypoint`: Add validation block — exits with clear error if secret is unset or placeholder
- `README.md`: Document `BASE_NODE_L2_ENGINE_AUTH_RAW` as a required field under Configuration → Required Settings

## Test plan

- [ ] Start node without setting `BASE_NODE_L2_ENGINE_AUTH_RAW` — confirm all entrypoints exit with error message and generation hint
- [ ] Set `BASE_NODE_L2_ENGINE_AUTH_RAW=$(openssl rand -hex 32)` — confirm node starts and containers authenticate successfully
- [ ] Verify no regressions with a valid secret set