### PR TITLE
fix: add autorestart to supervisord and healthcheck to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,12 @@ services:
       context: .
       dockerfile: Dockerfile
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", "http://localhost:8545/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     ports:
       - "8545:8545" # RPC
       - "8546:8546" # websocket
@@ -22,6 +28,12 @@ services:
     restart: unless-stopped
     depends_on:
       - execution
+    healthcheck:
+      test: ["CMD", "curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", "http://localhost:8545/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
     ports:
       - "7545:8545" # RPC
       - "9222:9222" # P2P TCP

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -9,6 +9,7 @@ stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 redirect_stderr=true
 stopwaitsecs=300
+autorestart=true
 
 [program:execution]
 command=/app/execution-entrypoint
@@ -16,3 +17,4 @@ stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 redirect_stderr=true
 stopwaitsecs=300
+autorestart=true


### PR DESCRIPTION
## Summary
- Add `autorestart=true` to both `[program:base-consensus]` and `[program:execution]` in supervisord.conf
- Add healthcheck blocks to both `execution` and `node` services in docker-compose.yml

## Problem
If the consensus client or execution client crashes, supervisord will not restart it automatically — the node stays down until an operator manually intervenes. Additionally, docker-compose shows services as "healthy" even if the process has exited.

## Solution
Two-part fix: supervisord auto-restart ensures process resilience within the container; docker healthcheck enables container-level observability via `docker compose ps`.

## Tests
`docker compose config` — verify YAML is valid and healthcheck is recognized

## Risk / Compatibility
- Risk: LOW
- Affects: configuration only; no chain sync or consensus behavior changed
- Healthcheck uses lightweight HTTP check on port 8545 — standard RPC port
- autorestart=true is standard supervisord configuration