### PR TITLE
fix: add autorestart=true to supervisord and healthcheck to docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ Base is a secure, low-cost, developer-friendly Ethereum L2 built on Optimism's [
 [![Twitter Base](https://img.shields.io/twitter/follow/Base?style=social)](https://x.com/Base)
 [![Farcaster Base](https://img.shields.io/badge/Farcaster_Base-3d8fcc)](https://farcaster.xyz/base)
 
+## Table of Contents
+- [Quick Start](#quick-start)
+- [Supported Clients](#supported-clients)
+- [Requirements](#requirements)
+- [Configuration](#configuration)
+- [Snapshots](#snapshots)
+- [Supported Networks](#supported-networks)
+- [Troubleshooting](#troubleshooting)
+
 ## Quick Start
 
 1. Ensure you have an Ethereum L1 full node RPC and beacon endpoint available.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,12 @@ services:
       - ${HOST_DATA_DIR:-./reth-data}:/data
     env_file:
       - ${NETWORK_ENV:-.env.mainnet} # Use .env.mainnet by default, override with .env.sepolia for testnet
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "-X", "POST", "http://localhost:8545", "--data", '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}']
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
   node:
     build:
       context: .

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -9,6 +9,7 @@ stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 redirect_stderr=true
 stopwaitsecs=300
+autorestart=true
 
 [program:execution]
 command=/app/execution-entrypoint
@@ -16,3 +17,4 @@ stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 redirect_stderr=true
 stopwaitsecs=300
+autorestart=true


### PR DESCRIPTION
Addresses issues #1054 and #1045.

If either the consensus client or execution client crashes, supervisord will now automatically restart it without requiring manual operator intervention.

Also adds a healthcheck to the execution service so `docker compose ps` accurately reflects service health rather than always showing healthy.