### PR TITLE
Avoid unauthenticated Engine API probe in consensus-entrypoint

### DIFF
--- a/consensus-entrypoint
+++ b/consensus-entrypoint
@@ -41,8 +41,11 @@ if [[ -z "${BASE_NODE_L2_ENGINE_AUTH_RAW:-}" ]]; then
   exit 1
 fi
 
-until [ "$(curl -s --max-time 10 --connect-timeout 5 -w '%{http_code}' -o /dev/null "${BASE_NODE_L2_ENGINE_RPC/ws/http}")" -eq 401 ]; do
-  echo "waiting for execution client to be ready"
+until curl -s --max-time 10 --connect-timeout 5 \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' \
+  http://execution:8545 | grep -q '"result":"0x2105"'; do
+  echo "waiting for execution client RPC to be ready"
   sleep 5
 done
 

--- a/consensus-entrypoint
+++ b/consensus-entrypoint
@@ -41,10 +41,11 @@ if [[ -z "${BASE_NODE_L2_ENGINE_AUTH_RAW:-}" ]]; then
   exit 1
 fi
 
+
 until curl -s --max-time 10 --connect-timeout 5 \
   -H 'Content-Type: application/json' \
   -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' \
-  http://execution:8545 | grep -q '"result":"0x2105"'; do
+  http://execution:8545 | grep -q '"result"'; do
   echo "waiting for execution client RPC to be ready"
   sleep 5
 done


### PR DESCRIPTION
## Summary

This PR updates the `consensus-entrypoint` readiness check to avoid probing the execution client's Engine/Auth RPC endpoint without JWT authentication.

Previously, the script used:

```bash
curl "${BASE_NODE_L2_ENGINE_RPC/ws/http}"

When BASE_NODE_L2_ENGINE_RPC=ws://execution:8551, this expands to:

http://execution:8551

This sends an unauthenticated request to the Engine/Auth RPC endpoint. base-reth-node correctly returns 401, but it also logs the request as an error:

Invalid JWT: Authorization header is missing or invalid

This is a false positive and can be confusing during node operations and debugging.

Change

Instead of probing the Engine/Auth RPC endpoint, this PR checks the regular execution JSON-RPC endpoint using eth_chainId:

curl -s --max-time 10 --connect-timeout 5 \
  -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' \
  http://execution:8545 | grep -q '"result":"0x2105"'
Motivation

This avoids generating misleading Invalid JWT errors in the execution logs while still ensuring that the execution client RPC is ready before starting base-consensus.