### PR TITLE
fix(compose): expose discovery v5 UDP port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,12 @@ services:
       dockerfile: Dockerfile
     restart: unless-stopped
     ports:
-      - "8545:8545" # RPC
-      - "8546:8546" # websocket
-      - "7301:6060" # metrics
-      - "30303:30303" # P2P TCP
-      - "30303:30303/udp" # P2P UDP
+    - "8545:8545" # RPC
+    - "8546:8546" # websocket
+    - "7301:6060" # metrics
+    - "30303:30303" # P2P TCP
+    - "30303:30303/udp" # P2P UDP
+    - "9200:9200/udp" # Discovery v5 UDP
     command: ["bash", "./execution-entrypoint"]
     volumes:
       - ${HOST_DATA_DIR:-./reth-data}:/data


### PR DESCRIPTION
## Summary

Exposes the execution client's discovery v5 UDP port in `docker-compose.yml`.

`execution-entrypoint` defaults `V5_DISCOVERY_PORT` to `9200` and passes it to reth through `--discovery.v5.port`, but the compose file only exposed `30303` TCP/UDP for the execution service.

This adds the missing UDP port mapping for discovery v5.

Fixes #1102

## Testing

- `docker compose config`