### PR TITLE
fix(entrypoint): respect operator-provided P2P_ADVERTISE_IP

### DIFF
--- a/consensus-entrypoint
+++ b/consensus-entrypoint
@@ -46,13 +46,15 @@ until [ "$(curl -s --max-time 10 --connect-timeout 5 -w '%{http_code}' -o /dev/n
   sleep 5
 done
 
-if PUBLIC_IP=$(get_public_ip); then
+if [[ -n "${BASE_NODE_P2P_ADVERTISE_IP:-}" ]]; then
+  echo "Using operator-provided BASE_NODE_P2P_ADVERTISE_IP: $BASE_NODE_P2P_ADVERTISE_IP"
+elif PUBLIC_IP=$(get_public_ip); then
   echo "fetched public IP is: $PUBLIC_IP"
+  export BASE_NODE_P2P_ADVERTISE_IP=$PUBLIC_IP
 else
   echo "Could not retrieve public IP."
   exit 8
 fi
-export BASE_NODE_P2P_ADVERTISE_IP=$PUBLIC_IP
 
 echo "$BASE_NODE_L2_ENGINE_AUTH_RAW" > "$BASE_NODE_L2_ENGINE_AUTH"
 


### PR DESCRIPTION
## What

Makes the `consensus-entrypoint` script respect `BASE_NODE_P2P_ADVERTISE_IP` if the operator has already set it, instead of always running IP discovery and potentially overriding or failing.

## The problem

The script unconditionally calls `get_public_ip()` (which tries `ifconfig.me`, `api.ipify.org`, `ipecho.net`, `v4.ident.me`) and exports the result as `BASE_NODE_P2P_ADVERTISE_IP`, even if the operator already configured this in their env file.

This causes two issues:

1. **Silent override**: If an operator sets `BASE_NODE_P2P_ADVERTISE_IP` to a specific value (e.g., a load balancer IP or a specific interface), the script ignores it and replaces it with whatever the discovery endpoints return.

2. **Hard failure on restricted networks**: If all four IP services are unreachable (firewalled host, restricted egress, transient network issues), the script exits with code 8 and the consensus container won't start — even when the operator already provided the correct IP.

## The fix

```bash
if [[ -n "${BASE_NODE_P2P_ADVERTISE_IP:-}" ]]; then
  echo "Using operator-provided BASE_NODE_P2P_ADVERTISE_IP: $BASE_NODE_P2P_ADVERTISE_IP"
elif PUBLIC_IP=$(get_public_ip); then
  echo "fetched public IP is: $PUBLIC_IP"
  export BASE_NODE_P2P_ADVERTISE_IP=$PUBLIC_IP
else
  echo "Could not retrieve public IP."
  exit 8
fi
```

Discovery only runs as a fallback when no value is provided. Existing operators who don't set this variable see no behavior change — the script still discovers their IP automatically.

Fixes #1107