### PR TITLE
ci: add shellcheck to PR pipeline

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,6 +33,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
+      - name: ShellCheck
+        run: |
+          which shellcheck || apt-get install -y shellcheck
+          shellcheck execution-entrypoint consensus-entrypoint
+
       - name: Build the Docker image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:


### PR DESCRIPTION
Add ShellCheck linting to PR workflow for shell script quality. Lints execution-entrypoint and consensus-entrypoint scripts.