### PR TITLE
config: expose Discv5 UDP port 9200 in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - "7301:6060" # metrics
       - "30303:30303" # P2P TCP
       - "30303:30303/udp" # P2P UDP
+      - "9200:9200/udp" # P2P Discovery v5
     command: ["bash", "./execution-entrypoint"]
     volumes:
       - ${HOST_DATA_DIR:-./reth-data}:/data


### PR DESCRIPTION
P2P discovery v5 peers unreachable without UDP 9200. Add port mapping 9200:9200/udp to execution service.