### PR TITLE
fix: correct RETH_PRUNING_ARGS condition logic

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - "7301:6060" # metrics
       - "30303:30303" # P2P TCP
       - "30303:30303/udp" # P2P UDP
+      - "9200:9200/udp" # P2P Discovery v5
     command: ["bash", "./execution-entrypoint"]
     volumes:
       - ${HOST_DATA_DIR:-./reth-data}:/data

--- a/execution-entrypoint
+++ b/execution-entrypoint
@@ -68,7 +68,7 @@ wait_for_pid() {
 }
 
 # Add pruning for base
-if [[ "${RETH_PRUNING_ARGS+x}" = x ]]; then
+if [[ -n "${RETH_PRUNING_ARGS:-}" ]]; then
     echo "Adding pruning arguments: $RETH_PRUNING_ARGS"
     ADDITIONAL_ARGS="$ADDITIONAL_ARGS $RETH_PRUNING_ARGS"
 fi


### PR DESCRIPTION
The condition '${var+x}' returns 'x' when the variable is unset, making the check TRUE when the variable is actually empty — and FALSE when it has a value. This is backwards: pruning args are silently dropped when set, and the echo statement runs with an empty value when unset.

Fix using '${var:-}' with '-n' to correctly test non-empty values.