### PR TITLE
fix: add configurable metrics port for consensus service

### DIFF
--- a/consensus-entrypoint
+++ b/consensus-entrypoint
@@ -53,12 +53,13 @@ else
   exit 8
 fi
 export BASE_NODE_P2P_ADVERTISE_IP=$PUBLIC_IP
+METRICS_PORT="${METRICS_PORT:-7300}"
 
 echo "$BASE_NODE_L2_ENGINE_AUTH_RAW" > "$BASE_NODE_L2_ENGINE_AUTH"
 
 if [[ -n "${BASE_NODE_SOURCE_L2_RPC:-}" ]]; then
   echo "Running base-consensus in follow mode because BASE_NODE_SOURCE_L2_RPC is set"
-  exec ./base-consensus follow
+  exec ./base-consensus follow --metrics=0.0.0.0:"$METRICS_PORT"
 else
-  exec ./base-consensus node
+  exec ./base-consensus node --metrics=0.0.0.0:"$METRICS_PORT"
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - "7301:6060" # metrics
       - "30303:30303" # P2P TCP
       - "30303:30303/udp" # P2P UDP
+      - "9200:9200/udp" # P2P Discovery v5
     command: ["bash", "./execution-entrypoint"]
     volumes:
       - ${HOST_DATA_DIR:-./reth-data}:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - "7545:8545" # RPC
       - "9222:9222" # P2P TCP
       - "9222:9222/udp" # P2P UDP
-      - "7300:7300" # metrics
+      - "${METRICS_PORT:-7300}:${METRICS_PORT:-7300}" # metrics
       - "6060:6060" # pprof
     command: ["bash", "./consensus-entrypoint"]
     env_file:


### PR DESCRIPTION
The consensus (node) service hardcodes port 7300 instead of using the METRICS_PORT environment variable. The .env files define BASE_NODE_METRICS_PORT but consensus-entrypoint never reads or passes this to the binary, and docker-compose uses a static mapping.

Changes:
- consensus-entrypoint: read METRICS_PORT, pass --metrics flag to binary
- docker-compose.yml: make port mapping configurable via METRICS_PORT