### PR TITLE
fix: add HOST_IP support to reth entrypoint

### DIFF
--- a/execution-entrypoint
+++ b/execution-entrypoint
@@ -127,6 +127,10 @@ if [[ "$RETH_HISTORICAL_PROOFS" == "true" && -n "$RETH_HISTORICAL_PROOFS_STORAGE
         --proofs-history.storage-path=$RETH_HISTORICAL_PROOFS_STORAGE_PATH
 fi
 
+if [ "${HOST_IP:+x}" = x ]; then
+    ADDITIONAL_ARGS="$ADDITIONAL_ARGS --nat=extip:$HOST_IP"
+fi
+
 mkdir -p "$RETH_DATA_DIR"
 echo "Starting reth with additional args: $ADDITIONAL_ARGS"
 echo "$BASE_NODE_L2_ENGINE_AUTH_RAW" > "$BASE_NODE_L2_ENGINE_AUTH"


### PR DESCRIPTION
Adds HOST_IP support to the reth execution client entrypoint, completing parity with geth and nethermind.

## Problem
The geth entrypoint has long supported HOST_IP via --nat=extip, and nethermind-entrypoint now supports it via --Network.ExternalIp. The reth entrypoint is the only execution client that ignores HOST_IP, causing reth operators running behind NAT to have degraded peer discovery and lower peer counts.

## Solution
Add the same conditional check (if [ "${HOST_IP:+x}" = x ]) to the reth entrypoint and append --nat=extip:$HOST_IP to ADDITIONAL_ARGS.