### PR TITLE
docs: document HOST_DATA_DIR and add default to env files

### DIFF
--- a/.env.mainnet
+++ b/.env.mainnet
@@ -53,3 +53,9 @@ STATSD_ADDRESS="172.17.0.1"
 # NOTE: The node type that was chosen when first running a node cannot be changed after the initial sync. Turning Archive into Pruned, or Pruned into Full is not supported [source](https://reth.rs/run/faq/pruning/).
 # NOTE: The pruned snapshots provided are set with a distance of 1_339_200 (~31 days).
 # RETH_PRUNING_ARGS="--prune.senderrecovery.distance=50000 --prune.transactionlookup.distance=50000 --prune.receipts.distance=50000 --prune.accounthistory.distance=50000 --prune.storagehistory.distance=50000 --prune.bodies.distance=50000"
+
+# DATA DIRECTORY
+# -----------------
+# Path on the host machine where chain data will be persisted.
+# Defaults to ./reth-data relative to docker-compose.yml if not set.
+HOST_DATA_DIR=./reth-data

--- a/.env.sepolia
+++ b/.env.sepolia
@@ -53,3 +53,9 @@ STATSD_ADDRESS="172.17.0.1"
 # NOTE: The node type that was chosen when first running a node cannot be changed after the initial sync. Turning Archive into Pruned, or Pruned into Full is not supported [source](https://reth.rs/run/faq/pruning/).
 # NOTE: The pruned snapshots provided are set with a distance of 1_339_200 (~31 days).
 # RETH_PRUNING_ARGS="--prune.senderrecovery.distance=50000 --prune.transactionlookup.distance=50000 --prune.receipts.distance=50000 --prune.accounthistory.distance=50000 --prune.storagehistory.distance=50000 --prune.bodies.distance=50000"
+
+# DATA DIRECTORY
+# -----------------
+# Path on the host machine where chain data will be persisted.
+# Defaults to ./reth-data relative to docker-compose.yml if not set.
+HOST_DATA_DIR=./reth-data

--- a/README.md
+++ b/README.md
@@ -21,7 +21,12 @@ Base is a secure, low-cost, developer-friendly Ethereum L2 built on Optimism's [
    BASE_NODE_L1_ETH_RPC=<your-preferred-l1-rpc>
    BASE_NODE_L1_BEACON=<your-preferred-l1-beacon>
    ```
-4. Start the node:
+4. Set the data directory (optional but recommended):
+   ```bash
+   HOST_DATA_DIR=./reth-data
+   ```
+   This path on the host machine is where chain data will be persisted. If not set, Docker will default to `./reth-data`.
+5. Start the node:
 
    ```bash
    # For mainnet (default):


### PR DESCRIPTION
## Summary

Documents the `HOST_DATA_DIR` environment variable and adds a sensible default (`./reth-data`) to both `.env.mainnet` and `.env.sepolia`.

## Problem

`docker-compose.yml` mounts chain data using `${HOST_DATA_DIR:-./reth-data}:/data`, but:

1. `HOST_DATA_DIR` is never mentioned in the README Quick Start guide.
2. Neither `.env.mainnet` nor `.env.sepolia` defines it, so operators who follow the docs may end up with an anonymous Docker volume that is hard to locate or accidentally pruned.

## Solution

- Add `HOST_DATA_DIR=./reth-data` (with an explanatory comment) to `.env.mainnet` and `.env.sepolia`.
- Add step 4 in the README Quick Start guide describing what `HOST_DATA_DIR` does and why it should be set.

## Impact

- New node operators are less likely to lose chain data due to missing volume configuration.
- The Quick Start now covers all required/strongly-recommended variables.