### PR TITLE
chore: remove unused CI FEATURES build-arg and dedupe compose image build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,10 +24,8 @@ jobs:
         settings:
           - arch: linux/amd64
             runs-on: ubuntu-24.04
-            features: jemalloc,asm-keccak,optimism
           - arch: linux/arm64
             runs-on: ubuntu-24.04-arm
-            features: jemalloc,optimism
     runs-on: ${{ matrix.settings.runs-on }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -63,8 +61,6 @@ jobs:
           file: Dockerfile
           tags: ${{ env.NAMESPACE }}/${{ env.RETH_IMAGE_NAME }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            FEATURES=${{ matrix.settings.features }}
           platforms: ${{ matrix.settings.arch }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,10 +14,8 @@ jobs:
         settings:
           - arch: linux/amd64
             runs-on: ubuntu-24.04
-            features: jemalloc,asm-keccak,optimism
           - arch: linux/arm64
             runs-on: ubuntu-24.04-arm
-            features: jemalloc,optimism
     runs-on: ${{ matrix.settings.runs-on }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -39,6 +37,4 @@ jobs:
           context: .
           file: Dockerfile
           push: false
-          build-args: |
-            FEATURES=${{ matrix.settings.features }}
           platforms: ${{ matrix.settings.arch }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   execution:
+    image: base-node:local
     build:
       context: .
       dockerfile: Dockerfile
@@ -16,9 +17,7 @@ services:
     env_file:
       - ${NETWORK_ENV:-.env.mainnet} # Use .env.mainnet by default, override with .env.sepolia for testnet
   node:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: base-node:local
     restart: unless-stopped
     depends_on:
       - execution


### PR DESCRIPTION
## Summary

- Drop the unused `FEATURES` build-arg from PR and release Docker workflows. The `Dockerfile` does not declare `ARG FEATURES`, and `cargo build` does not pass `--features`, so the matrix values had no effect (leftover from an older client layout).
- Build the node image once in Compose: `execution` builds `base-node:local`, and `node` reuses the same image instead of running a second identical build.

## Motivation

CI suggested feature flags were being applied when they were not. Locally, `docker compose up --build` compiled the same Dockerfile twice for `execution` and `node`, doubling build time without changing runtime behavior.

## Changes

- `.github/workflows/pr.yml` — remove `features` matrix field and `build-args: FEATURES=...`
- `.github/workflows/docker.yml` — same
- `docker-compose.yml` — add `image: base-node:local` to both services; keep `build` only on `execution`

## Test plan
- [x] Compose structure verified (single `build` on `execution`, shared `base-node:local` image)
- [x] CI workflows no longer pass unused `FEATURES` build-arg
- [ ] `docker compose config` / `docker compose build` — skipped locally (Docker not installed in WSL)
- [ ] PR CI Docker build (amd64 + arm64) — pending after PR open