### PR TITLE
fix: add autorestart to supervisord for process resilience

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -5,6 +5,7 @@ logfile_maxbytes=0
 
 [program:base-consensus]
 command=/app/consensus-entrypoint
+autorestart=true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 redirect_stderr=true
@@ -12,6 +13,7 @@ stopwaitsecs=300
 
 [program:execution]
 command=/app/execution-entrypoint
+autorestart=true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 redirect_stderr=true


### PR DESCRIPTION
This change adds autorestart=true to both the base-consensus and execution programs in supervisord.conf. This ensures that if either process crashes unexpectedly, supervisord will
     automatically restart it, improving node resilience.