### PR TITLE
docs: improve README with prerequisites, verification steps, and configuration details

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,22 @@ Base is a secure, low-cost, developer-friendly Ethereum L2 built on Optimism's [
 [![Twitter Base](https://img.shields.io/twitter/follow/Base?style=social)](https://x.com/Base)
 [![Farcaster Base](https://img.shields.io/badge/Farcaster_Base-3d8fcc)](https://farcaster.xyz/base)
 
+## Prerequisites
+
+Before running a Base node, ensure you have the following installed and configured:
+
+- **Docker** v20.10 or higher — [Install Docker](https://docs.docker.com/get-docker/)
+- **Docker Compose** v2.0 or higher — [Install Docker Compose](https://docs.docker.com/compose/install/)
+- **An Ethereum L1 full node RPC endpoint** — options include [Alchemy](https://www.alchemy.com/), [Infura](https://www.infura.io/), [QuickNode](https://www.quicknode.com/), or your own self-hosted node
+- **An Ethereum L1 Beacon endpoint** — required for consensus layer communication
+
+To verify your Docker installation:
+
+```bash
+docker --version
+docker compose version
+```
+
 ## Quick Start
 
 1. Ensure you have an Ethereum L1 full node RPC and beacon endpoint available.
@@ -31,6 +47,28 @@ Base is a secure, low-cost, developer-friendly Ethereum L2 built on Optimism's [
    NETWORK_ENV=.env.sepolia docker compose up --build
    ```
 
+5. Verify your node is running correctly:
+
+   ```bash
+   # Check that containers are running
+   docker compose ps
+
+   # Check node logs for sync progress
+   docker compose logs -f
+
+   # Query the node's current block number
+   curl -X POST \
+     --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
+     http://localhost:8545
+   ```
+
+   A successful response will look like:
+   ```json
+   {"jsonrpc":"2.0","id":1,"result":"0x..."}
+   ```
+
+   It may take several minutes for the node to begin syncing. Use snapshots (see below) to speed up initial sync significantly.
+
 ## Supported Clients
 
 - Execution: `base-reth-node`
@@ -43,8 +81,10 @@ Base is a secure, low-cost, developer-friendly Ethereum L2 built on Optimism's [
 - Modern multicore CPU
 - 32GB RAM (64GB recommended)
 - NVMe SSD drive
-- Storage: (2 * [current chain size](https://base.org/stats) + [snapshot size](https://basechaindata.vercel.app) + 20% buffer) to accommodate future growth
-- Docker and Docker Compose
+- Storage: `(2 × current chain size) + snapshot size + 20% buffer` to accommodate future growth
+  - Example: if the current chain size is 500GB and snapshot is 200GB, you need at least `(2 × 500) + 200 + 20% = ~1.44TB`
+  - Check current chain size at [base.org/stats](https://base.org/stats) and snapshot size at [basechaindata.vercel.app](https://basechaindata.vercel.app)
+- Docker and Docker Compose (see [Prerequisites](#prerequisites))
 
 ### Production Hardware Specifications
 
@@ -78,9 +118,10 @@ The following are the hardware specifications we use in production:
 
 ### Optional Features
 
-- Flashblocks: set `RETH_FB_WEBSOCKET_URL`. When set, the execution client runs in Flashblocks mode; otherwise it runs in vanilla mode.
-- Follow mode: set `BASE_NODE_SOURCE_L2_RPC`
-- Pruning: set `RETH_PRUNING_ARGS`
+- **Flashblocks**: set `RETH_FB_WEBSOCKET_URL`. When set, the execution client runs in Flashblocks mode; otherwise it runs in vanilla mode.
+- **Follow mode**: set `BASE_NODE_SOURCE_L2_RPC`
+- **Pruning**: set `RETH_PRUNING_ARGS`
+- **L1 Verifier Confirmation Depth**: set `BASE_NODE_VERIFIER_L1_CONFS` to configure the number of L1 confirmations the verifier waits before processing. Can also be set via the `--l1.verifier-confs` CLI flag. Useful for node operators who want to adjust confirmation depth based on their L1 provider's reliability.
 
 For full configuration options, see `.env.mainnet` or `.env.sepolia`.
 
@@ -105,9 +146,38 @@ Snapshots are available to help you sync your node more quickly. See [docs.base.
 | Mainnet | ✅ |
 | Testnet | ✅ |
 
+## Upgrading
+
+When a new version of `base-reth-node` or `base-consensus` is released, update your node by pulling the latest images and restarting:
+
+```bash
+docker compose pull
+docker compose down
+docker compose up --build
+```
+
+Check the [releases page](https://github.com/base-org/node/releases) for changelog and any breaking changes before upgrading.
+
+> **Note for pruned node operators**: some releases may be mandatory for pruned nodes while remaining optional for archive nodes. Always check the release notes to determine whether an upgrade is required for your node type.
+
 ## Troubleshooting
 
-For support please join our [Discord](https://discord.gg/buildonbase) and post in `🛠｜node-operators`. You can alternatively open a new GitHub issue.
+### Common Issues
+
+**Node not syncing:**
+- Verify your L1 RPC and beacon endpoints are accessible and not rate-limited
+- Check logs with `docker compose logs -f` for error messages
+- Ensure your storage has sufficient free space
+
+**Container exits immediately:**
+- Run `docker compose logs` to see the error output
+- Verify all required environment variables are set correctly in your `.env` file
+
+**RPC not responding:**
+- Confirm the node is fully started with `docker compose ps`
+- Check that port `8545` is not blocked by a firewall
+
+For additional support, join our [Discord](https://discord.gg/buildonbase) and post in `🛠｜node-operators`. You can alternatively open a new GitHub issue.
 
 ## Disclaimer
 


### PR DESCRIPTION
This PR improves the README for node operators with the following additions:

- **Prerequisites section** — Docker version requirements and verification commands so operators know exactly what's needed before starting
- **Node verification steps** — how to confirm the node is running correctly after startup including an eth_blockNumber health check
- **Concrete storage example** — clarifies the storage formula with real numbers (e.g. 500GB chain + 200GB snapshot = ~1.44TB)
- **BASE_NODE_VERIFIER_L1_CONFS documentation** — env variable introduced in v0.15.3 that was undocumented
- **Upgrading section** — step-by-step upgrade commands with a note for pruned node operators
- **Troubleshooting section** — three common issues with solutions