### PR TITLE
chore: update base/base to v1.1.0

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -1,3 +1,3 @@
-export BASE_RETH_NODE_COMMIT=955a18b189196c6f663235140180e5bcf51cd044
+export BASE_RETH_NODE_COMMIT=a3c3011b16dae73aaea455ec0a5ff614e65b7d0a
 export BASE_RETH_NODE_REPO=https://github.com/base/base.git
-export BASE_RETH_NODE_TAG=v1.0.1
+export BASE_RETH_NODE_TAG=v1.1.0


### PR DESCRIPTION
## Summary
- update the base/base source tag from v1.0.1 to v1.1.0
- update the pinned commit hash to the peeled v1.1.0 tag commit

## Testing
- verified versions.env resolves to the v1.1.0 tag commit with git ls-remote
- git diff --check