### PR TITLE
fix: build and ship basectl in the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN . /tmp/versions.env && git clone $BASE_RETH_NODE_REPO . && \
     git checkout tags/$BASE_RETH_NODE_TAG && \
     bash -c '[ "$(git rev-parse HEAD)" = "$BASE_RETH_NODE_COMMIT" ]' || (echo "Commit hash verification failed" && exit 1)
 
-RUN cargo build --bin base-reth-node --bin base-consensus --profile maxperf
+RUN cargo build --bin base-reth-node --bin base-consensus --bin basectl --profile maxperf
 
 FROM ubuntu:24.04
 
@@ -48,6 +48,7 @@ RUN mkdir -p /var/log/supervisor
 
 WORKDIR /app
 
+COPY --from=reth-base /app/target/maxperf/basectl ./
 COPY --from=reth-base /app/target/maxperf/base-consensus ./
 COPY --from=reth-base /app/target/maxperf/base-reth-node ./
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf


### PR DESCRIPTION
## Summary
- build `basectl` in the Docker builder stage alongside `base-reth-node` and `base-consensus`
- copy `basectl` into the runtime image so it is available in the published container
- align the node image with the binaries already published upstream for the pinned Base release