### PR TITLE
docs: document RETH_HISTORICAL_PROOFS optional feature

### DIFF
--- a/.env.mainnet
+++ b/.env.mainnet
@@ -48,6 +48,11 @@ STATSD_ADDRESS="172.17.0.1"
 # FLASHBLOCKS (OPTIONAL - UNCOMMENT TO ENABLE)
 # RETH_FB_WEBSOCKET_URL=wss://mainnet.flashblocks.base.org/ws
 
+# HISTORICAL PROOFS (OPTIONAL - UNCOMMENT TO ENABLE)
+# Enables historical proof generation. Initialization may take up to 6 hours on first run.
+# RETH_HISTORICAL_PROOFS=true
+# RETH_HISTORICAL_PROOFS_STORAGE_PATH=/data/proofs
+
 # PRUNING (OPTIONAL - UNCOMMENT TO ENABLE)
 # NOTE: Set to any number of blocks you want, but it should be >10064
 # NOTE: The node type that was chosen when first running a node cannot be changed after the initial sync. Turning Archive into Pruned, or Pruned into Full is not supported [source](https://reth.rs/run/faq/pruning/).

--- a/.env.sepolia
+++ b/.env.sepolia
@@ -48,6 +48,11 @@ STATSD_ADDRESS="172.17.0.1"
 # FLASHBLOCKS (OPTIONAL - UNCOMMENT TO ENABLE)
 # RETH_FB_WEBSOCKET_URL=wss://sepolia.flashblocks.base.org/ws
 
+# HISTORICAL PROOFS (OPTIONAL - UNCOMMENT TO ENABLE)
+# Enables historical proof generation. Initialization may take up to 6 hours on first run.
+# RETH_HISTORICAL_PROOFS=true
+# RETH_HISTORICAL_PROOFS_STORAGE_PATH=/data/proofs
+
 # PRUNING (OPTIONAL - UNCOMMENT TO ENABLE)
 # NOTE: Set to any number of blocks you want, but it should be >10064
 # NOTE: The node type that was chosen when first running a node cannot be changed after the initial sync. Turning Archive into Pruned, or Pruned into Full is not supported [source](https://reth.rs/run/faq/pruning/).

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ The following are the hardware specifications we use in production:
 - Flashblocks: set `RETH_FB_WEBSOCKET_URL`. When set, the execution client runs in Flashblocks mode; otherwise it runs in vanilla mode.
 - Follow mode: set `BASE_NODE_SOURCE_L2_RPC`
 - Pruning: set `RETH_PRUNING_ARGS`
+- Historical Proofs: set `RETH_HISTORICAL_PROOFS=true` and `RETH_HISTORICAL_PROOFS_STORAGE_PATH=<path>`. Enables historical proof generation. Note: initialization may take up to 6 hours on first run.
 
 For full configuration options, see `.env.mainnet` or `.env.sepolia`.
 


### PR DESCRIPTION
## What changed? Why?

The `execution-entrypoint` supports Historical Proofs via `RETH_HISTORICAL_PROOFS` and `RETH_HISTORICAL_PROOFS_STORAGE_PATH` environment variables, but these were not documented in the README or the `.env` template files.

All other optional features (Flashblocks, Follow mode, Pruning) follow a consistent pattern: documented in README + commented in `.env.mainnet` and `.env.sepolia`. This PR applies the same pattern to Historical Proofs.

**Changes:**
- `README.md`: Added Historical Proofs to the Optional Features section
- `.env.mainnet`: Added commented Historical Proofs section before Pruning
- `.env.sepolia`: Added commented Historical Proofs section before Pruning

## Notes to reviewers

No code changes — documentation only. The feature already exists in `execution-entrypoint` (lines 77-128).

## How has it been tested?

Verified against `execution-entrypoint` source to confirm variable names and behavior.