### PR TITLE
feat: make max-outbound-peers configurable via MAX_OUTBOUND_PEERS env var

### DIFF
--- a/.env.mainnet
+++ b/.env.mainnet
@@ -48,6 +48,12 @@ STATSD_ADDRESS="172.17.0.1"
 # FLASHBLOCKS (OPTIONAL - UNCOMMENT TO ENABLE)
 # RETH_FB_WEBSOCKET_URL=wss://mainnet.flashblocks.base.org/ws
 
+# PEER LIMITS (OPTIONAL - UNCOMMENT TO OVERRIDE DEFAULTS)
+# --------------------------------------------------------
+# Increase MAX_OUTBOUND_PEERS if you see persistent "Send Queue full" warnings.
+# See: https://github.com/base/node/issues/1063
+# MAX_OUTBOUND_PEERS=100
+
 # PRUNING (OPTIONAL - UNCOMMENT TO ENABLE)
 # NOTE: Set to any number of blocks you want, but it should be >10064
 # NOTE: The node type that was chosen when first running a node cannot be changed after the initial sync. Turning Archive into Pruned, or Pruned into Full is not supported [source](https://reth.rs/run/faq/pruning/).

--- a/.env.sepolia
+++ b/.env.sepolia
@@ -48,6 +48,12 @@ STATSD_ADDRESS="172.17.0.1"
 # FLASHBLOCKS (OPTIONAL - UNCOMMENT TO ENABLE)
 # RETH_FB_WEBSOCKET_URL=wss://sepolia.flashblocks.base.org/ws
 
+# PEER LIMITS (OPTIONAL - UNCOMMENT TO OVERRIDE DEFAULTS)
+# --------------------------------------------------------
+# Increase MAX_OUTBOUND_PEERS if you see persistent "Send Queue full" warnings.
+# See: https://github.com/base/node/issues/1063
+# MAX_OUTBOUND_PEERS=100
+
 # PRUNING (OPTIONAL - UNCOMMENT TO ENABLE)
 # NOTE: Set to any number of blocks you want, but it should be >10064
 # NOTE: The node type that was chosen when first running a node cannot be changed after the initial sync. Turning Archive into Pruned, or Pruned into Full is not supported [source](https://reth.rs/run/faq/pruning/).

--- a/execution-entrypoint
+++ b/execution-entrypoint
@@ -10,6 +10,7 @@ METRICS_PORT="${METRICS_PORT:-6060}"
 DISCOVERY_PORT="${DISCOVERY_PORT:-30303}"
 V5_DISCOVERY_PORT="${V5_DISCOVERY_PORT:-9200}"
 P2P_PORT="${P2P_PORT:-30303}"
+MAX_OUTBOUND_PEERS="${MAX_OUTBOUND_PEERS:-100}"
 ADDITIONAL_ARGS=""
 BINARY="./base-reth-node"
 RETH_HISTORICAL_PROOFS="${RETH_HISTORICAL_PROOFS:-false}"
@@ -150,7 +151,7 @@ exec "$BINARY" node \
   --authrpc.port="$AUTHRPC_PORT" \
   --authrpc.jwtsecret="$BASE_NODE_L2_ENGINE_AUTH" \
   --metrics=0.0.0.0:"$METRICS_PORT" \
-  --max-outbound-peers=100 \
+  --max-outbound-peers="$MAX_OUTBOUND_PEERS" \
   --chain "$RETH_CHAIN" \
   --rollup.sequencer-http="$RETH_SEQUENCER_HTTP" \
   --rollup.disable-tx-pool-gossip \


### PR DESCRIPTION
Reopening this contribution (previously #1081, closed by stale-bot without review) — makes max-outbound-peers configurable via MAX_OUTBOUND_PEERS env var, useful for operators tuning peer connectivity who hit the 'Send Queue full' issue referenced in #1063. Default behavior unchanged (100 peers). Rebased on latest main, no conflicts. Happy to address any review feedback.