### PR TITLE
docs: document Reth port and log level variables in env files

### DIFF
--- a/.env.mainnet
+++ b/.env.mainnet
@@ -48,6 +48,22 @@ STATSD_ADDRESS="172.17.0.1"
 # FLASHBLOCKS (OPTIONAL - UNCOMMENT TO ENABLE)
 # RETH_FB_WEBSOCKET_URL=wss://mainnet.flashblocks.base.org/ws
 
+# PORT CONFIGURATION (OPTIONAL - UNCOMMENT TO OVERRIDE DEFAULTS)
+# ---------------------------------------------------------------
+# Override default ports when running multiple nodes or to resolve conflicts.
+# RPC_PORT=8545          # HTTP JSON-RPC port
+# WS_PORT=8546           # WebSocket JSON-RPC port
+# AUTHRPC_PORT=8551      # Engine API (authenticated RPC) port
+# METRICS_PORT=6060      # Prometheus metrics port
+# DISCOVERY_PORT=30303   # P2P discovery port
+# V5_DISCOVERY_PORT=9200 # discv5 discovery port
+# P2P_PORT=30303         # P2P TCP port
+
+# LOG LEVEL (OPTIONAL - UNCOMMENT TO OVERRIDE DEFAULT)
+# -----------------------------------------------------
+# Supported values: error, warn, info, debug, trace (default: info)
+# LOG_LEVEL=info
+
 # PRUNING (OPTIONAL - UNCOMMENT TO ENABLE)
 # NOTE: Set to any number of blocks you want, but it should be >10064
 # NOTE: The node type that was chosen when first running a node cannot be changed after the initial sync. Turning Archive into Pruned, or Pruned into Full is not supported [source](https://reth.rs/run/faq/pruning/).

--- a/.env.sepolia
+++ b/.env.sepolia
@@ -48,6 +48,22 @@ STATSD_ADDRESS="172.17.0.1"
 # FLASHBLOCKS (OPTIONAL - UNCOMMENT TO ENABLE)
 # RETH_FB_WEBSOCKET_URL=wss://sepolia.flashblocks.base.org/ws
 
+# PORT CONFIGURATION (OPTIONAL - UNCOMMENT TO OVERRIDE DEFAULTS)
+# ---------------------------------------------------------------
+# Override default ports when running multiple nodes or to resolve conflicts.
+# RPC_PORT=8545          # HTTP JSON-RPC port
+# WS_PORT=8546           # WebSocket JSON-RPC port
+# AUTHRPC_PORT=8551      # Engine API (authenticated RPC) port
+# METRICS_PORT=6060      # Prometheus metrics port
+# DISCOVERY_PORT=30303   # P2P discovery port
+# V5_DISCOVERY_PORT=9200 # discv5 discovery port
+# P2P_PORT=30303         # P2P TCP port
+
+# LOG LEVEL (OPTIONAL - UNCOMMENT TO OVERRIDE DEFAULT)
+# -----------------------------------------------------
+# Supported values: error, warn, info, debug, trace (default: info)
+# LOG_LEVEL=info
+
 # PRUNING (OPTIONAL - UNCOMMENT TO ENABLE)
 # NOTE: Set to any number of blocks you want, but it should be >10064
 # NOTE: The node type that was chosen when first running a node cannot be changed after the initial sync. Turning Archive into Pruned, or Pruned into Full is not supported [source](https://reth.rs/run/faq/pruning/).


### PR DESCRIPTION
Reopening this contribution (previously #1077, closed by stale-bot without review) — documents the Reth port and log level variables that execution-entrypoint already defines but which were previously undocumented in the .env files. Purely additive documentation, no behavior change. Rebased on latest main, no conflicts. Happy to address any review feedback.