### PR TITLE
fix: respect pre-set BASE_NODE_P2P_ADVERTISE_IP in consensus-entrypoint

### DIFF
--- a/consensus-entrypoint
+++ b/consensus-entrypoint
@@ -46,13 +46,18 @@ until [ "$(curl -s --max-time 10 --connect-timeout 5 -w '%{http_code}' -o /dev/n
   sleep 5
 done
 
-if PUBLIC_IP=$(get_public_ip); then
-  echo "fetched public IP is: $PUBLIC_IP"
+if [[ -z "${BASE_NODE_P2P_ADVERTISE_IP:-}" ]]; then
+  if PUBLIC_IP=$(get_public_ip); then
+    echo "fetched public IP is: $PUBLIC_IP"
+  else
+    echo "Could not retrieve public IP."
+    exit 8
+  fi
+  export BASE_NODE_P2P_ADVERTISE_IP=$PUBLIC_IP
 else
-  echo "Could not retrieve public IP."
-  exit 8
+  echo "using pre-set BASE_NODE_P2P_ADVERTISE_IP: $BASE_NODE_P2P_ADVERTISE_IP"
+  export BASE_NODE_P2P_ADVERTISE_IP
 fi
-export BASE_NODE_P2P_ADVERTISE_IP=$PUBLIC_IP
 
 echo "$BASE_NODE_L2_ENGINE_AUTH_RAW" > "$BASE_NODE_L2_ENGINE_AUTH"
 


### PR DESCRIPTION
Fixes #1107

## What changed?

`consensus-entrypoint` now only runs public IP discovery when `BASE_NODE_P2P_ADVERTISE_IP` is not already set. If the operator provided a value, the script logs it and uses it as-is. Behavior when the variable is unset is unchanged: discovery runs against the same four providers and a total failure still exits with code 8.

## Why?

As reported in #1107, the script unconditionally called `get_public_ip` and then `export BASE_NODE_P2P_ADVERTISE_IP=$PUBLIC_IP`, which

1. silently overwrote any advertise IP the operator configured (NAT/proxy setups where the routable IP differs from the egress IP), and
2. made startup hard-fail with exit 8 on hosts with restricted egress to the four IP-echo services, even when the operator had already supplied the value discovery was meant to provide.

## How has it been tested?

- `bash -n` syntax check.
- Exercised the guard with a stubbed `curl` in all three scenarios:
  - variable pre-set + discovery unreachable → keeps the operator value and continues (previously exit 8),
  - variable unset + discovery reachable → fetches and exports the discovered IP as before,
  - variable unset + discovery unreachable → still exits 8, unchanged.